### PR TITLE
fix: resolve race condition in worker allocation for multi-instance radio

### DIFF
--- a/src/core/music-player.ts
+++ b/src/core/music-player.ts
@@ -704,14 +704,21 @@ async function startRadio(interaction: ChatInputCommandInteraction): Promise<voi
 
   try {
     // Ensure queue exists (or create new one)
+    logger.info(`[radio] Starting radio for channel ${voiceChannel.id}`);
     let queue = await validateAndCleanupQueue(interaction, voiceChannel.id);
 
     if (!queue) {
+      logger.info(`[radio] No existing queue, assigning worker...`);
       const worker = await assignWorker(interaction, voiceChannel, true);
-      if (!worker) return;
+      if (!worker) {
+        logger.warn(`[radio] Failed to assign worker`);
+        return;
+      }
+      logger.info(`[radio] Assigned worker ${worker.name}`);
       queue = await createQueue(interaction, worker, null);
     } else {
       // Re-acquire worker if idle
+      logger.info(`[radio] Reusing existing queue/worker ${queue.worker.name}`);
       const success = await reacquireIdleWorker(interaction, queue);
       if (!success) return;
     }
@@ -724,6 +731,7 @@ async function startRadio(interaction: ChatInputCommandInteraction): Promise<voi
 
     // If nothing is playing, start radio immediately
     if (!queue.nowPlaying && queue.songs.length === 0) {
+      logger.info(`[radio] Queue empty, starting playback immediately`);
       await handleRadio(queue);
     } else {
       const channelName = await getChannelName(

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -192,6 +192,10 @@ function allocateWorker(guildId: string, voiceChannelId: string): WorkerState | 
 
     // 3. Use AFR to select a worker
     const selected = selectFelineWithAFR(eligibleWorkers);
+
+    // CRITICAL: Mark as busy immediately to prevent race conditions
+    setWorkerBusy(selected, guildId, voiceChannelId);
+
     return selected;
 }
 


### PR DESCRIPTION
Fixes an issue where multiple radio instances could not be started simultaneously due to a race condition in worker allocation. Also adds logging for better debugging.