### PR TITLE
fix(audio): support ephemeral attachment URLs

### DIFF
--- a/apps/bot/src/core/audio/stream-handler.ts
+++ b/apps/bot/src/core/audio/stream-handler.ts
@@ -24,10 +24,15 @@ export function isUrl(text: string): boolean {
 }
 
 export function isAttachmentUrl(text: string): boolean {
-    // Discord uses multiple domains for attachments
+    // Discord uses multiple domains and paths for attachments
+    // Regular attachments: /attachments/
+    // Slash command attachments: /ephemeral-attachments/
     return text.includes("cdn.discordapp.com/attachments") ||
+        text.includes("cdn.discordapp.com/ephemeral-attachments") ||
         text.includes("media.discordapp.net/attachments") ||
-        text.includes("cdn.discord.com/attachments");
+        text.includes("media.discordapp.net/ephemeral-attachments") ||
+        text.includes("cdn.discord.com/attachments") ||
+        text.includes("cdn.discord.com/ephemeral-attachments");
 }
 
 export interface VideoData {


### PR DESCRIPTION
## Description
Fixes an issue where slash command file attachments would fail to play.

## Changes
- Updated `isAttachmentUrl` to support the `/ephemeral-attachments/` path used by Discord for slash command uploads.
- Consolidated attachment URL detection logic to include `cdn.discord.com` and `media.discordapp.net`.

## Testing
- Verified locally that `/play file:[attachment]` now works correctly.