### PR TITLE
fix: add missing React imports and update garage-band submodule

### DIFF
--- a/PLUGINS_DEV.md
+++ b/PLUGINS_DEV.md
@@ -212,7 +212,7 @@ Plugins can extend the web dashboard using React components.
 > **✅ Correct:**
 >
 > ```typescript
-> import { useEffect, useState } from '@jasper/elements';
+> import { React, useEffect, useState } from '@jasper/elements';
 > ```
 >
 > **❌ Incorrect:**
@@ -244,8 +244,7 @@ The frontend entry point must export components that you want to register. It do
 ### Basic Structure
 
 ```tsx
-import React from 'react';
-
+import { React } from '@jasper/elements';
 import { Button, Card } from '@jasper/ui';
 
 // Component for the dashboard widget

--- a/apps/bot/src/plugins/dashboard-notes/web/index.tsx
+++ b/apps/bot/src/plugins/dashboard-notes/web/index.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, ReactRouterDOM, useEffect, useState } from '@jasper/elements';
+import { FormEvent, React, ReactRouterDOM, useEffect, useState } from '@jasper/elements';
 import { Badge, Button, Card, Input, Loader, Table } from '@jasper/ui';
 import { Clipboard, Plus, Trash2 } from 'lucide-react';
 


### PR DESCRIPTION
## Description
Fixes the `ReferenceError: React is not defined` error thrown in the web UI when built with Vite's classic JSX runtime.
Components in `dashboard-notes` now explicitly import `React` from `@jasper/elements`.
Also updates the `garage-band` submodule to the new commit bridging identical fixes.
I've also fixed contradicting code examples in `PLUGINS_DEV.md` to reflect the explicit import requirement.

### Related PRs
- Submodule fixes: purrfectsoft/jasper-plugin-garage-band#5