### PR TITLE
fix: correct pnpm filter syntax for workspace dependencies

### DIFF
--- a/apps/bot/scripts/export-plugin.ts
+++ b/apps/bot/scripts/export-plugin.ts
@@ -39,7 +39,7 @@ if (!isSourceExport) {
     console.log('Building backend...');
     try {
         execSync(
-            'pnpm run build --filter "jasper-bot^..." && pnpm exec tsc && pnpm tsx scripts/build-plugins.ts ' +
+            'pnpm --filter "jasper-bot^..." run build && pnpm exec tsc && pnpm tsx scripts/build-plugins.ts ' +
                 PLUGIN_ID,
             {
                 stdio: 'inherit',


### PR DESCRIPTION
Follow up to #73. The previous command passed the filter argument to the underlying script instead of pnpm. This fixes it to use pnpm's workspace filtering.