### PR TITLE
Migrate private submodule checkout to GitHub App Auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
               with:
                   app-id: ${{ secrets.DEPLOY_APP_ID }}
                   private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+                  owner: purrfectsoft
 
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,18 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Generate GitHub App Token
+              id: generate-token
+              uses: actions/create-github-app-token@v1
+              with:
+                  app-id: ${{ secrets.DEPLOY_APP_ID }}
+                  private-key: ${{ secrets.DEPLOY_APP_PRIVATE_KEY }}
+
             - name: Checkout code
               uses: actions/checkout@v4
               with:
                   submodules: recursive
-                  token: ${{ secrets.PAT_TOKEN || github.token }}
+                  token: ${{ steps.generate-token.outputs.token }}
 
             - name: Install pnpm
               uses: pnpm/action-setup@v2


### PR DESCRIPTION
Resolves #63

### Changes
- Replaced the personal access token (`PAT_TOKEN`) with a dynamically generated GitHub App installation token in `.github/workflows/deploy.yml`
- Integrated `actions/create-github-app-token@v1` in the checkout sequence to support private cross-repository submodule clone permissions