### PR TITLE
fix(plugins): conditionally resolve aliases and bump garage-band

### DIFF
--- a/apps/bot/scripts/build-plugins.ts
+++ b/apps/bot/scripts/build-plugins.ts
@@ -110,11 +110,18 @@ async function buildPlugins() {
                     const pkg = JSON.parse(fs.readFileSync(pluginPkgPath, 'utf-8'));
                     const deps = { ...pkg.dependencies, ...pkg.devDependencies };
                     for (const dep of Object.keys(deps)) {
-                        aliases[dep] = path.resolve(pluginDir, 'node_modules', dep);
+                        const depPath = path.resolve(pluginDir, 'node_modules', dep);
+                        if (fs.existsSync(depPath)) {
+                            aliases[dep] = depPath;
+                        }
                     }
                 } catch (e) {
                     console.warn(`Warning: Failed to parse package.json for alias mapping:`, e);
                 }
+            } else {
+                console.warn(
+                    `[plugins] Warning: Plugin "${pluginId}" has frontend code but no package.json was found in ${pluginDir}.`,
+                );
             }
 
             try {

--- a/apps/bot/scripts/build-plugins.ts
+++ b/apps/bot/scripts/build-plugins.ts
@@ -110,7 +110,12 @@ async function buildPlugins() {
             if (fs.existsSync(pluginPkgPath)) {
                 try {
                     const pkg = JSON.parse(fs.readFileSync(pluginPkgPath, 'utf-8'));
-                    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+                    const deps = {
+                        ...(pkg && typeof pkg.dependencies === 'object' ? pkg.dependencies : null),
+                        ...(pkg && typeof pkg.devDependencies === 'object'
+                            ? pkg.devDependencies
+                            : null),
+                    };
                     for (const dep of Object.keys(deps)) {
                         if (dep.startsWith('@types/')) continue;
                         try {

--- a/apps/bot/scripts/build-plugins.ts
+++ b/apps/bot/scripts/build-plugins.ts
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build } from 'vite';
@@ -7,6 +8,7 @@ import { build } from 'vite';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PLUGINS_DIR = path.resolve(__dirname, '../src/plugins');
 const DIST_DIR = path.resolve(__dirname, '../dist/plugins');
+const require = createRequire(import.meta.url);
 
 async function buildPlugins() {
     if (!fs.existsSync(PLUGINS_DIR)) {
@@ -110,9 +112,15 @@ async function buildPlugins() {
                     const pkg = JSON.parse(fs.readFileSync(pluginPkgPath, 'utf-8'));
                     const deps = { ...pkg.dependencies, ...pkg.devDependencies };
                     for (const dep of Object.keys(deps)) {
-                        const depPath = path.resolve(pluginDir, 'node_modules', dep);
-                        if (fs.existsSync(depPath)) {
-                            aliases[dep] = depPath;
+                        if (dep.startsWith('@types/')) continue;
+                        try {
+                            const resolvedPath = require.resolve(dep, { paths: [pluginDir] });
+                            aliases[dep] = resolvedPath;
+                        } catch (resolveError) {
+                            console.warn(
+                                `[plugins] Warning: Could not resolve dependency "${dep}" for plugin "${pluginId}":`,
+                                resolveError instanceof Error ? resolveError.message : resolveError,
+                            );
                         }
                     }
                 } catch (e) {


### PR DESCRIPTION
Retroactively addresses Code Review feedback on PR #113 by only registering resolve aliases if the local directory path exists in the plugin's node_modules. Also bumps the submodule pointer to include name/version fields in package.json.