### PR TITLE
fix(plugins): exclude hidden files and folders from asset copying

### DIFF
--- a/apps/bot/scripts/build-plugins.ts
+++ b/apps/bot/scripts/build-plugins.ts
@@ -67,11 +67,12 @@ async function buildPlugins() {
 
                     if (stat.isDirectory()) {
                         // Skip web source, hidden folders, and output dirs
-                        if (['web', 'node_modules', 'dist', '.git'].includes(item)) continue;
+                        if (['web', 'node_modules', 'dist'].includes(item) || item.startsWith('.'))
+                            continue;
                         copyAssets(srcPath, destPath);
                     } else if (stat.isFile()) {
                         const ext = path.extname(item).toLowerCase();
-                        // Skip source code and config files
+                        // Skip source code, config files, and hidden/system files
                         if (
                             [
                                 '.ts',
@@ -84,7 +85,7 @@ async function buildPlugins() {
                                 '.yaml',
                                 '.yml',
                             ].includes(ext) ||
-                            item === '.git'
+                            item.startsWith('.')
                         ) {
                             continue;
                         }

--- a/apps/bot/scripts/build-plugins.ts
+++ b/apps/bot/scripts/build-plugins.ts
@@ -67,8 +67,12 @@ async function buildPlugins() {
 
                     if (stat.isDirectory()) {
                         // Skip web source, hidden folders, and output dirs
-                        if (['web', 'node_modules', 'dist'].includes(item) || item.startsWith('.'))
+                        if (
+                            ['web', 'node_modules', 'dist'].includes(item) ||
+                            item.startsWith('.')
+                        ) {
                             continue;
+                        }
                         copyAssets(srcPath, destPath);
                     } else if (stat.isFile()) {
                         const ext = path.extname(item).toLowerCase();


### PR DESCRIPTION
Excludes hidden dotfiles (like .gitignore) and dotfolders (like .git) from being copied as static assets. This prevents checksum mismatches in Deploy Bot where hidden files are omitted during packaging.