### PR TITLE
feat(audio): implement multi-track gain control audio engine integration

### DIFF
--- a/apps/bot/src/core/audio/playback-engine.ts
+++ b/apps/bot/src/core/audio/playback-engine.ts
@@ -272,8 +272,11 @@ export async function playSong(queue: Queue): Promise<void> {
 
         const resource = createAudioResource(audioSource, {
             inputType: StreamType.Arbitrary,
-            inlineVolume: false,
+            inlineVolume: true,
         });
+
+        const effectiveGain = typeof song.gain === 'number' ? song.gain : (typeof queue.gain === 'number' ? queue.gain : 1.0);
+        resource.volume?.setVolume(effectiveGain);
 
         queue.player.play(resource);
 

--- a/packages/types/src/bot-types.ts
+++ b/packages/types/src/bot-types.ts
@@ -33,6 +33,7 @@ export interface Song {
     fromCache?: boolean;
     startTime?: number;
     sourceType?: 'youtube' | 'attachment' | 'direct';
+    gain?: number;
 }
 
 export interface Queue {
@@ -54,6 +55,7 @@ export interface Queue {
     loopTrack?: boolean;
     loopQueue?: boolean;
     skipping?: boolean;
+    gain?: number;
 }
 
 // --- Database Types (Shared) ---


### PR DESCRIPTION
## Summary
- Integrates multi-track gain control and master playlist gain multiplier between the `garage-band` plugin and Jasper core.
- Adds `gain?: number` property to `Song` and `Queue` interfaces in `@jasper/types`.
- Configures `createAudioResource` in `playback-engine.ts` with `inlineVolume: true` and applies effective volume gain scaling.
- Bumps `garage-band` submodule pointer to commit `f94c3b4` (Submodule PR purrfectsoft/jasper-plugin-garage-band#17).

Resolves #100