### PR TITLE
feat(skills): add cross-tool agent skills sync engine and curated skills

### DIFF
--- a/.agent/skills
+++ b/.agent/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.agents/overlays/grill-with-docs.md
+++ b/.agents/overlays/grill-with-docs.md
@@ -1,0 +1,14 @@
+## Document Grounding Protocol (Jasper & Hosted Jasper)
+
+Before forming the design decision tree and computing the first frontier:
+
+1. **Scan Target Specifications**:
+    - Locate and ingest relevant definitions in `docs/hosted-jasper/` (`mvp-scope.md`, `mvp-issue-plan.md`, `architecture.md`) or any user-provided path.
+    - Ground against the active rules in `.agent/rules/` (`development.md`, `plugins.md`, `code-review.md`, `workflow.md`).
+
+2. **Constraint Verification**:
+    - Explicitly verify whether the proposed design crosses the public engine (`sakibtamim/Jasper`) / private control plane (`purrfectsoft/jasper-hosted`) boundary.
+    - Probe for multi-tenant safety (`TenantId` isolation), database dialect parity (SQLite + PostgreSQL), and idempotency constraints.
+
+3. **Frontier Formulation**:
+    - Frame frontier questions with explicit citations to the grounded documents.

--- a/.agents/overlays/to-spec.md
+++ b/.agents/overlays/to-spec.md
@@ -1,0 +1,14 @@
+## Jasper & Hosted Jasper Architecture Context
+
+When generating specs for Jasper features or `HJ-OSS-*` issues:
+
+1. **Hosted Jasper Definition Pack**:
+    - Always verify and align with the canonical specification in `docs/hosted-jasper/` (`mvp-scope.md`, `mvp-issue-plan.md`, `architecture.md`).
+    - Preserve the strict public/private boundary between the public engine (`sakibtamim/Jasper`) and private hosted control plane (`purrfectsoft/jasper-hosted`).
+
+2. **Development Standards & Seams**:
+    - Align with `.agent/rules/development.md`: Strict TypeScript (no `any`), ESM with explicit `.js` imports, functional React UI components, and Fastify type parameters.
+    - For database operations, isolate domain queries behind adapter interfaces (`apps/bot/src/core/db/`) supporting both SQLite and PostgreSQL parity.
+
+3. **Issue Creation Compliance**:
+    - Structure final output to match `.agent/rules/workflow.md`: Preamble/Objective, Acceptance Criteria (checkbox list), Implementation Brief, and QA Checklist.

--- a/.agents/overlays/to-tickets.md
+++ b/.agents/overlays/to-tickets.md
@@ -1,0 +1,17 @@
+## Jasper Issue Standards Alignment
+
+When converting specifications into GitHub issues:
+
+1. **Issue Title Format**:
+    - Use human-readable descriptions (e.g., "Implement Dynamic API Port Allocation").
+    - **Do NOT** prefix issue titles with conventional commit tags (e.g., no `feat:`, `fix:`).
+
+2. **Required Issue Structure** (per `.agent/rules/workflow.md`):
+    - **Objective / Preamble**: High-level problem and motivation.
+    - **Acceptance Criteria**: Checkbox list (`- [ ] ...`) of concrete requirements.
+    - **Implementation Brief**: Technical architecture and affected packages/modules.
+    - **QA Checklist**: Step-by-step verification commands or test cases.
+
+3. **Labels**:
+    - Apply exactly one `type:*` label (`type: feature`, `type: enhancement`, `type: bug`, `type: infra`, `type: docs`).
+    - Add a `priority:*` label (`priority: P0`, `priority: P1`, `priority: P2`, `priority: P3`).

--- a/.agents/skills.manifest.json
+++ b/.agents/skills.manifest.json
@@ -1,0 +1,79 @@
+{
+    "version": "1.0.0",
+    "sources": {
+        "mattpocock": {
+            "repo": "mattpocock/skills",
+            "branch": "main",
+            "baseUrl": "https://raw.githubusercontent.com/mattpocock/skills/main/skills"
+        },
+        "pstack": {
+            "repo": "cursor/plugins",
+            "branch": "main",
+            "baseUrl": "https://raw.githubusercontent.com/cursor/plugins/main/pstack/skills"
+        }
+    },
+    "skills": {
+        "typescript-best-practices": {
+            "source": "pstack",
+            "sourcePath": "typescript-best-practices",
+            "scope": "project",
+            "files": ["SKILL.md", "references/patterns.md"]
+        },
+        "boundary-discipline": {
+            "source": "pstack",
+            "sourcePath": "principle-boundary-discipline",
+            "scope": "project",
+            "files": ["SKILL.md"]
+        },
+        "unslop": {
+            "source": "pstack",
+            "sourcePath": "unslop",
+            "scope": "project",
+            "files": ["SKILL.md"]
+        },
+        "tdd": {
+            "source": "mattpocock",
+            "sourcePath": "engineering/tdd",
+            "scope": "project",
+            "files": ["SKILL.md", "mocking.md", "tests.md"]
+        },
+        "migrate-then-delete-legacy-apis": {
+            "source": "pstack",
+            "sourcePath": "principle-migrate-callers-then-delete-legacy-apis",
+            "scope": "project",
+            "files": ["SKILL.md"]
+        },
+        "resolving-merge-conflicts": {
+            "source": "mattpocock",
+            "sourcePath": "engineering/resolving-merge-conflicts",
+            "scope": "project",
+            "files": ["SKILL.md"]
+        },
+        "to-spec": {
+            "source": "mattpocock",
+            "sourcePath": "engineering/to-spec",
+            "scope": "project",
+            "overlay": ".agents/overlays/to-spec.md",
+            "files": ["SKILL.md"]
+        },
+        "grill-me": {
+            "source": "mattpocock",
+            "sourcePath": "productivity/grilling",
+            "scope": "global",
+            "name": "grill-me",
+            "files": ["SKILL.md"]
+        },
+        "reflect": {
+            "source": "pstack",
+            "sourcePath": "reflect",
+            "scope": "global",
+            "files": [
+                "SKILL.md",
+                "references/divergent-reviewer.md",
+                "references/judgment-reviewer.md",
+                "references/synthesizer.md",
+                "references/tooling-reviewer.md"
+            ]
+        }
+    }
+}

--- a/.agents/skills.manifest.json
+++ b/.agents/skills.manifest.json
@@ -56,6 +56,47 @@
             "overlay": ".agents/overlays/to-spec.md",
             "files": ["SKILL.md"]
         },
+        "grill-with-docs": {
+            "source": "mattpocock",
+            "sourcePath": "productivity/grilling",
+            "name": "grill-with-docs",
+            "scope": "project",
+            "overlay": ".agents/overlays/grill-with-docs.md",
+            "files": ["SKILL.md"]
+        },
+        "why": {
+            "source": "pstack",
+            "sourcePath": "why",
+            "scope": "project",
+            "files": [
+                "SKILL.md",
+                "references/epistemics.md",
+                "references/source-playbook.md",
+                "references/sources/code-archaeology.md",
+                "references/sources/incident-postmortem.md"
+            ]
+        },
+        "make-operations-idempotent": {
+            "source": "pstack",
+            "sourcePath": "principle-make-operations-idempotent",
+            "name": "make-operations-idempotent",
+            "scope": "project",
+            "files": ["SKILL.md"]
+        },
+        "separate-before-serializing-shared-state": {
+            "source": "pstack",
+            "sourcePath": "principle-separate-before-serializing-shared-state",
+            "name": "separate-before-serializing-shared-state",
+            "scope": "project",
+            "files": ["SKILL.md"]
+        },
+        "to-tickets": {
+            "source": "mattpocock",
+            "sourcePath": "engineering/to-tickets",
+            "scope": "project",
+            "overlay": ".agents/overlays/to-tickets.md",
+            "files": ["SKILL.md"]
+        },
         "grill-me": {
             "source": "mattpocock",
             "sourcePath": "productivity/grilling",

--- a/.agents/skills/boundary-discipline/SKILL.md
+++ b/.agents/skills/boundary-discipline/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: principle-boundary-discipline
+description: 'Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, config, network, external APIs); trust internal types and keep business logic in pure functions.'
+disable-model-invocation: true
+---
+
+# Boundary Discipline
+
+Place validation, type narrowing, and error handling at system boundaries. Trust internal code unconditionally. Business logic lives in pure functions; the shell is thin and mechanical.
+
+**Why:** Scattered validation is noisy, redundant, and gives a false sense of safety. Validate data once at the boundary. Keep logic out of framework wiring so it can be tested without the framework.
+
+**The pattern:**
+
+- **At boundaries** (CLI args, config files, external APIs, network protocols): validate, return errors, handle defensively.
+- **Inside the system:** typed data, error propagation, no re-validation. Trust the types.
+- **Across the boundary.** Expose domain concepts, not the boundary's private representation. Keep general-purpose mechanism inside and special-purpose policy at the edge.
+
+**Applications:**
+
+Validation and error handling:
+
+- Validate config at parse time (the boundary), not inside business logic
+- Parse raw data into domain types at the boundary
+- Do not re-export transport, storage, framework, or wire types through the public surface
+- No redundant nil checks deep in call chains if the boundary already validated
+
+Code organization:
+
+- Business logic in pure functions with no framework dependencies
+- Parse functions: pure transforms from raw bytes to typed state
+- Prompt construction: structured state in, string out
+- Scoring and assessment: pure transforms from state to results
+
+**The tests:**
+
+- "Is this data crossing a system boundary right now?" If not, validation is redundant.
+- "Can this be a pure function that the shell just calls?" If yes, extract it.

--- a/.agents/skills/boundary-discipline/SKILL.md
+++ b/.agents/skills/boundary-discipline/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: principle-boundary-discipline
+name: boundary-discipline
 description: 'Apply when wiring validation, error handling, or framework adapters. Concentrate guards at system boundaries (CLI, config, network, external APIs); trust internal types and keep business logic in pure functions.'
 disable-model-invocation: true
 ---

--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: grill-with-docs
+description: Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, or uses any 'grill' trigger phrases.
+---
+
+Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
+
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled: the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
+
+Format a round like so:
+
+```
+❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
+
+➡️ <your recommended answer>
+
+---
+
+❓ **Q2** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
+
+➡️ <your recommended answer>
+```
+
+Each round the user answers reshapes the tree: settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a _later_ round, not this one.
+
+Finding _facts_ is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it; don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report; ask the rest of the frontier now. The _decisions_ are the user's: put each to them and wait.
+
+The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.
+
+---
+
+## Document Grounding Protocol (Jasper & Hosted Jasper)
+
+Before forming the design decision tree and computing the first frontier:
+
+1. **Scan Target Specifications**:
+    - Locate and ingest relevant definitions in `docs/hosted-jasper/` (`mvp-scope.md`, `mvp-issue-plan.md`, `architecture.md`) or any user-provided path.
+    - Ground against the active rules in `.agent/rules/` (`development.md`, `plugins.md`, `code-review.md`, `workflow.md`).
+
+2. **Constraint Verification**:
+    - Explicitly verify whether the proposed design crosses the public engine (`sakibtamim/Jasper`) / private control plane (`purrfectsoft/jasper-hosted`) boundary.
+    - Probe for multi-tenant safety (`TenantId` isolation), database dialect parity (SQLite + PostgreSQL), and idempotency constraints.
+
+3. **Frontier Formulation**:
+    - Frame frontier questions with explicit citations to the grounded documents.

--- a/.agents/skills/make-operations-idempotent/SKILL.md
+++ b/.agents/skills/make-operations-idempotent/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: make-operations-idempotent
+description: 'Apply when designing commands, lifecycle steps, or processing loops that run amid crashes, restarts, and retries. Converge to the same end state regardless of partial prior runs.'
+disable-model-invocation: true
+---
+
+# Make Operations Idempotent
+
+Design operations so they converge to the correct state regardless of how many times they run or where they start from. Every state-mutating operation should answer: "What happens if this runs twice? What happens if the previous run crashed halfway?"
+
+**Why:** Commands, lifecycle operations, and processing loops run where crashes, restarts, and retries are normal. If partial state changes the next run's outcome, every restart becomes a debugging session.
+
+**The pattern:**
+
+- Convergent startup: scan for existing state, clean stale artifacts, adopt live sessions
+- Content-based cleanup: compare by content equivalence, not creation order
+- Self-healing locks: use PID-based stale lock detection
+- Idempotent scheduling: failed work respawns cleanly, fresh input regenerated after each cycle
+
+**The test:**
+
+1. What happens if this runs twice in a row?
+2. What happens if the previous run crashed at every possible point?
+3. Does re-execution converge to the same end state?
+
+If any answer is "it depends on what state was left behind," the operation needs a reconciliation step.

--- a/.agents/skills/migrate-then-delete-legacy-apis/SKILL.md
+++ b/.agents/skills/migrate-then-delete-legacy-apis/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: principle-migrate-callers-then-delete-legacy-apis
+description: 'Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the same wave instead of preserving compatibility layers.'
+disable-model-invocation: true
+---
+
+# Migrate Callers Then Delete Legacy APIs
+
+When we decide a new API is the right design, migrate callers and remove the old API in the same refactor wave instead of preserving compatibility layers.
+
+**Rule:**
+
+- Do not keep legacy API paths alive only because internal callers still exist
+- Inventory callers, migrate them, and delete the old API immediately
+- Treat temporary adapters as exceptional and time-boxed, not default architecture
+- Update tests to assert the new contract, and delete tests that only protect pre-refactor implementation details
+
+**When this applies:**
+
+- No external users depend on backward compatibility
+- The project can absorb coordinated breaking changes
+- The new API is part of a simplification or refactor initiative
+
+Keeping both old and new APIs creates dual-path complexity, slows cleanup, and makes the codebase feel append-only.

--- a/.agents/skills/migrate-then-delete-legacy-apis/SKILL.md
+++ b/.agents/skills/migrate-then-delete-legacy-apis/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: principle-migrate-callers-then-delete-legacy-apis
+name: migrate-then-delete-legacy-apis
 description: 'Apply when introducing a new internal API while old callers still exist. Migrate callers and delete the old API in the same wave instead of preserving compatibility layers.'
 disable-model-invocation: true
 ---

--- a/.agents/skills/resolving-merge-conflicts/SKILL.md
+++ b/.agents/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: resolving-merge-conflicts
+description: 'Use when you need to resolve an in-progress git merge/rebase conflict.'
+---
+
+1. **See the current state** of the merge/rebase. Check git history, and the conflicting files.
+
+2. **Find the primary sources** for each conflict. Understand deeply why each change was made, and what the original intent was. Read the commit messages, check the PRs, check original issues/tickets.
+
+3. **Resolve each hunk.** Preserve both intents where possible. Where incompatible, pick the one matching the merge's stated goal and note the trade-off. Do **not** invent new behaviour. Always resolve; never `--abort`.
+
+4. Discover the project's **automated checks** and run them, typically typecheck, then tests, then format. Fix anything the merge broke.
+
+5. **Finish the merge/rebase.** Stage everything and commit. If rebasing, continue the rebase process until all commits are rebased.

--- a/.agents/skills/separate-before-serializing-shared-state/SKILL.md
+++ b/.agents/skills/separate-before-serializing-shared-state/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: separate-before-serializing-shared-state
+description: 'Apply when concurrent actors might write to the same file, branch, key, or state object. Eliminate the sharing first; serialize structurally only when one shared writer is a real invariant.'
+disable-model-invocation: true
+---
+
+# Separate Before Serializing Shared State
+
+When concurrent actors might share mutable state, first ask whether they truly need the same mutable object. If not, eliminate the sharing. When sharing is real, enforce serialization structurally: lockfiles, sequential phases, exclusive ownership. Instructions and conventions are not concurrency control.
+
+**Why:** Concurrent writes to shared state create race conditions that are intermittent, hard to reproduce, and expensive to debug. Telling agents or goroutines to "take turns" does not work.
+
+**Pattern:**
+
+1. **Identify shared mutable state** (files both read and write, branches both push to, APIs both define and consume).
+2. **Default: eliminate the shared write target.** Ask: do these actors need one canonical object, or are they publishing independent facts? Give each actor its own owned file, key, branch, or state directory, and merge only at the read/reporting boundary. Two workers writing their own `lastX` field into one `state.json` is still shared mutation; `indexer-state.json` + `metrics-state.json` is not.
+3. **Only when one shared write target is a real invariant, serialize access structurally** (lockfiles, sequential phases, single-writer actor, or atomic compare-and-swap). Treat "we need a lock" as a design smell to check, not as the default answer.

--- a/.agents/skills/tdd/SKILL.md
+++ b/.agents/skills/tdd/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tdd
+description: Test-driven development. Use when the user wants to build features or fix bugs test-first, mentions "red-green-refactor", or wants integration tests.
+---
+
+# Test-Driven Development
+
+TDD is the red → green loop. This skill is the reference that makes that loop produce tests worth keeping: what a good test is, where tests go, the anti-patterns, and the rules of the loop. Every section applies on every cycle: consult them before and during the loop, not after.
+
+When exploring the codebase, read `CONTEXT.md` (if it exists) so test names and interface vocabulary match the project's domain language, and respect ADRs in the area you're touching.
+
+## What a good test is
+
+Tests verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't. A good test reads like a specification: "user can checkout with valid cart" tells you exactly what capability exists, and it survives refactors because it doesn't care about internal structure.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Seams: where tests go
+
+A **seam** is the public boundary you test at: the interface where you observe behavior without reaching inside. Tests live at seams, never against internals.
+
+**Test only at pre-agreed seams.** Before writing any test, write down the seams under test and confirm them with the user. No test is written at an unconfirmed seam. You can't test everything, so agreeing the seams up front is how testing effort lands on the critical paths and complex logic instead of every edge case.
+
+Ask: "What's the public interface, and which seams should we test?"
+
+When the shape of that interface is itself in question (how deep the module is, where the seam belongs, what the interface should expose), call the Skill tool with "codebase-design" for the vocabulary. It is the shared source of the module, interface, depth, seam, adapter, leverage and locality terms, and it is a reference to consult, not a session to run.
+
+## Anti-patterns
+
+- **Implementation-coupled**: mocks internal collaborators, tests private methods, or verifies through a side channel (querying the database instead of using the interface). The tell: the test breaks when you refactor but behavior hasn't changed.
+- **Tautological**: the assertion recomputes the expected value the way the code does (`expect(add(a, b)).toBe(a + b)`, a snapshot derived by hand the same way, a constant asserted equal to itself), so it passes by construction and can never disagree with the code. Expected values must come from an independent source of truth: a known-good literal, a worked example, the spec.
+- **Horizontal slicing**: writing all tests first, then all implementation. Bulk tests verify _imagined_ behavior: you test the _shape_ of things rather than user-facing behavior, the tests go insensitive to real changes, and you commit to test structure before understanding the implementation. Work in **vertical slices** instead: one test → one implementation → repeat, each test a **tracer bullet** that responds to what the last cycle taught you.
+
+## Rules of the loop
+
+- **Red before green.** Write the failing test first, then only enough code to pass it. Don't anticipate future tests or add speculative features.
+- **One slice at a time.** One seam, one test, one minimal implementation per cycle.
+- **Refactoring is not part of the loop.** It belongs to the review stage (see the `code-review` skill), not the red → green implementation cycle.

--- a/.agents/skills/tdd/mocking.md
+++ b/.agents/skills/tdd/mocking.md
@@ -1,0 +1,60 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+    return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+    const client = new StripeClient(process.env.STRIPE_KEY);
+    return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.agents/skills/tdd/tests.md
+++ b/.agents/skills/tdd/tests.md
@@ -1,0 +1,77 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test('user can checkout with valid cart', async () => {
+    const cart = createCart();
+    cart.add(product);
+    const result = await checkout(cart, paymentMethod);
+    expect(result.status).toBe('confirmed');
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test('checkout calls paymentService.process', async () => {
+    const mockPayment = jest.mock(paymentService);
+    await checkout(cart, payment);
+    expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test('createUser saves to database', async () => {
+    await createUser({ name: 'Alice' });
+    const row = await db.query('SELECT * FROM users WHERE name = ?', ['Alice']);
+    expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test('createUser makes user retrievable', async () => {
+    const user = await createUser({ name: 'Alice' });
+    const retrieved = await getUser(user.id);
+    expect(retrieved.name).toBe('Alice');
+});
+```
+
+**Tautological tests**: Expected value restates the implementation, so the test passes by construction.
+
+```typescript
+// BAD: Expected value is recomputed the way the code computes it
+test('calculateTotal sums line items', () => {
+    const items = [{ price: 10 }, { price: 5 }];
+    const expected = items.reduce((sum, i) => sum + i.price, 0);
+    expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: Expected value is an independent, known literal
+test('calculateTotal sums line items', () => {
+    expect(calculateTotal([{ price: 10 }, { price: 5 }])).toBe(15);
+});
+```

--- a/.agents/skills/to-spec/SKILL.md
+++ b/.agents/skills/to-spec/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: to-spec
+description: "Turn the current conversation into a spec and publish it to the project issue tracker: no interview, just synthesis of what you've already discussed."
+disable-model-invocation: true
+---
+
+This skill takes the current conversation context and codebase understanding and produces a spec. Do NOT interview the user; just synthesize what you already know.
+
+The issue tracker and triage label vocabulary should have been provided to you. If not, tell the user to run `/setup-matt-pocock-skills`.
+
+## Process
+
+1. Explore the repo to understand the current state of the codebase, if you haven't already. Use the project's domain glossary vocabulary throughout the spec, and respect any ADRs in the area you're touching.
+
+2. Sketch out the seams at which you're going to test the feature. Existing seams should be preferred to new ones. Use the highest seam possible. If new seams are needed, propose them at the highest point you can. The fewer seams across the codebase, the better - the ideal number is one.
+
+Check with the user that these seams match their expectations.
+
+3. Write the spec using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
+
+<spec-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts, not a working demo, just the important bits.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this spec.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</spec-template>
+
+---
+
+## Jasper & Hosted Jasper Architecture Context
+
+When generating specs for Jasper features or `HJ-OSS-*` issues:
+
+1. **Hosted Jasper Definition Pack**:
+    - Always verify and align with the canonical specification in `docs/hosted-jasper/` (`mvp-scope.md`, `mvp-issue-plan.md`, `architecture.md`).
+    - Preserve the strict public/private boundary between the public engine (`sakibtamim/Jasper`) and private hosted control plane (`purrfectsoft/jasper-hosted`).
+
+2. **Development Standards & Seams**:
+    - Align with `.agent/rules/development.md`: Strict TypeScript (no `any`), ESM with explicit `.js` imports, functional React UI components, and Fastify type parameters.
+    - For database operations, isolate domain queries behind adapter interfaces (`apps/bot/src/core/db/`) supporting both SQLite and PostgreSQL parity.
+
+3. **Issue Creation Compliance**:
+    - Structure final output to match `.agent/rules/workflow.md`: Preamble/Objective, Acceptance Criteria (checkbox list), Implementation Brief, and QA Checklist.

--- a/.agents/skills/to-tickets/SKILL.md
+++ b/.agents/skills/to-tickets/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: to-tickets
+description: Break a plan, spec, or the current conversation into a set of tracer-bullet tickets, each declaring its blocking edges, published to the configured tracker (edges as text in one file per ticket locally, or native blocking links on a real tracker).
+disable-model-invocation: true
+---
+
+# To Tickets
+
+Break a plan, spec, or conversation into a set of **tickets**: tracer-bullet vertical slices, each declaring the tickets that **block** it.
+
+The issue tracker and triage label vocabulary should have been provided to you. If not, tell the user to run `/setup-matt-pocock-skills`.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes a reference (a spec path, an issue number or URL) as an argument, fetch it and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Ticket titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+Look for opportunities to prefactor the code to make the implementation easier. "Make the change easy, then make the easy change."
+
+### 3. Draft vertical slices
+
+Break the work into **tracer bullet** tickets.
+
+<vertical-slice-rules>
+
+- Each slice cuts a narrow but COMPLETE path through every layer (schema, API, UI, tests): vertical, NOT a horizontal slice of one layer
+- A completed slice is demoable or verifiable on its own
+- Each slice is sized to fit in a single fresh context window
+- Any prefactoring should be done first
+
+</vertical-slice-rules>
+
+Give each ticket its **blocking edges**: the other tickets that must complete before it can start. A ticket with no blockers can start immediately.
+
+**Wide refactors are the exception to vertical slicing.** A **wide refactor** is one mechanical change (rename a column, retype a shared symbol) whose **blast radius** fans across the whole codebase, so a single edit breaks thousands of call sites at once and no vertical slice can land green. Don't force it into a tracer bullet; sequence it as **expand–contract**. First expand: add the new form beside the old so nothing breaks. Then migrate the call sites over in batches sized by blast radius (per package, per directory), each batch its own ticket blocked by the expand, keeping CI green batch to batch because the old form still exists. Finally contract: delete the old form once no caller remains, in a ticket blocked by every migrate batch. When even the batches can't stay green alone, keep the sequence but let them share an integration branch that all block a final integrate-and-verify ticket; green is promised only there.
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each ticket, show:
+
+- **Title**: short descriptive name
+- **Blocked by**: which other tickets (if any) must complete first
+- **What it delivers**: the end-to-end behaviour this ticket makes work
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the blocking edges correct: does each ticket only depend on tickets that genuinely gate it?
+- Should any tickets be merged or split further?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the tickets to the configured tracker
+
+Publish the approved tickets. **How** depends on the tracker `/setup-matt-pocock-skills` configured; the tickets are the same either way, only the shape of the blocking edges changes:
+
+- **Local files** → write one file per ticket under `.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` in dependency order (blockers first). Each file's "Blocked by" lists the numbers/titles it depends on. Use the per-ticket file template below: one ticket per file, never a single combined file.
+- **A real issue tracker (GitHub, Linear, …)** → publish one issue per ticket in dependency order (blockers first) so each ticket's blocking edges can reference real identifiers. Use the platform's native blocking / sub-issue relationship where it has one; otherwise set each ticket's "Blocked by" to the blocking issues. Apply the `ready-for-agent` triage label unless instructed otherwise; the tickets are agent-grabbable by construction.
+
+Work the **frontier**: any ticket whose blockers are all done. For a purely linear chain that means top to bottom.
+
+Do NOT close or modify any parent issue.
+
+<local-ticket-template>
+
+# <NN>: <Ticket title>
+
+**What to build:** the end-to-end behaviour this ticket makes work, from the user's perspective, not a layer-by-layer implementation list.
+
+**Blocked by:** the numbers/titles of the tickets that gate this one, or "None (can start immediately)".
+
+**Status:** ready-for-agent
+
+- [ ] Acceptance criterion 1
+- [ ] Acceptance criterion 2
+
+</local-ticket-template>
+
+<issue-template>
+
+## Parent
+
+A reference to the parent issue on the tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+The end-to-end behaviour this ticket makes work, from the user's perspective, not layer-by-layer implementation.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Blocked by
+
+- A reference to each blocking ticket, or "None (can start immediately)".
+
+</issue-template>
+
+In either form, avoid specific file paths or code snippets: they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it and note briefly that it came from a prototype. Trim to the decision-rich parts, not a working demo, just the important bits.
+
+---
+
+## Jasper Issue Standards Alignment
+
+When converting specifications into GitHub issues:
+
+1. **Issue Title Format**:
+    - Use human-readable descriptions (e.g., "Implement Dynamic API Port Allocation").
+    - **Do NOT** prefix issue titles with conventional commit tags (e.g., no `feat:`, `fix:`).
+
+2. **Required Issue Structure** (per `.agent/rules/workflow.md`):
+    - **Objective / Preamble**: High-level problem and motivation.
+    - **Acceptance Criteria**: Checkbox list (`- [ ] ...`) of concrete requirements.
+    - **Implementation Brief**: Technical architecture and affected packages/modules.
+    - **QA Checklist**: Step-by-step verification commands or test cases.
+
+3. **Labels**:
+    - Apply exactly one `type:*` label (`type: feature`, `type: enhancement`, `type: bug`, `type: infra`, `type: docs`).
+    - Add a `priority:*` label (`priority: P0`, `priority: P1`, `priority: P2`, `priority: P3`).

--- a/.agents/skills/typescript-best-practices/SKILL.md
+++ b/.agents/skills/typescript-best-practices/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: typescript-best-practices
+description: TypeScript best practices. Use when reading or editing any .ts or .tsx file.
+---
+
+# TypeScript best practices
+
+Apply the **type-system-discipline** principle skill first; this skill grounds it in TypeScript syntax.
+
+| Rule                  | Summary                                                                                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Discriminated unions  | Model variants with a `kind` literal discriminant so impossible states can't be represented. No optional-field bags.                                                                                           |
+| Branded types         | Brand primitives with `& { readonly __brand: "X" }` so they can't be mixed up. Validate once at creation.                                                                                                      |
+| Constructive modeling | Build the shape so the illegal value can't be constructed. `[T, ...T[]]` for non-empty, `[T, T][]` for even length, `start` plus `duration` for a range. Not a runtime guard, not a wish for refinement types. |
+| Simplest total type   | Keep `T[]` while every operation on it stays total. Strengthen to `NonEmpty<T>` only where the loose type forces `!`, a cast, or a "should never happen" throw.                                                |
+| `unknown` over `any`  | External data is `unknown`. `any` disables type checking everywhere it touches.                                                                                                                                |
+| No `as` casts         | Every `as` is a runtime crash waiting. Cast only after validation.                                                                                                                                             |
+| Narrowing hierarchy   | Discriminant switch > `in` operator > `typeof`/`instanceof` > user-defined type guard > `as`.                                                                                                                  |
+| Type guards           | Must verify the claim. A lying guard is worse than `as` because the bug hides behind a name that says it's safe. Name them `isX` or `hasX`.                                                                    |
+| Exhaustiveness        | Inline `const _exhaustive: never = x;` in default arms so the compiler errors when a new variant is added.                                                                                                     |
+| `satisfies` over `as` | Validates the value without widening literal types.                                                                                                                                                            |
+| Boundary validation   | Parse where data crosses in, into a named domain type. `Record<string, unknown>` (however spelled) stops at that parse. Trust types inside. See the **boundary-discipline** principle skill.                   |
+| Schema-derived types  | Reach for `Pick`/`Omit`/`Parameters`/`ReturnType`/`Awaited`/`typeof` before declaring a new interface.                                                                                                         |
+| Object args           | Pass objects, not positional, so argument order is self-documenting. Skip on hot paths (per-frame render, tokenizers, parsers).                                                                                |
+| Real tests            | Don't mock what you can run. Prefer the framework's real test primitives with leak/disposable checks, and verify UI in a running build. Mock only what you can't run locally.                                  |
+| Structured telemetry  | Prefer structured logger diagnostics with enough context to debug from an id. No `console.log` in shipped code.                                                                                                |
+
+Examples: `references/patterns.md`.

--- a/.agents/skills/typescript-best-practices/references/patterns.md
+++ b/.agents/skills/typescript-best-practices/references/patterns.md
@@ -1,0 +1,293 @@
+# TypeScript patterns
+
+Code examples for each rule in `SKILL.md`. The underlying principles are language-agnostic; see the **type-system-discipline** and **boundary-discipline** principle skills.
+
+## Branded types
+
+Brand primitives so they can't be mixed up. Validate once at creation; downstream code trusts the type.
+
+```ts
+type AgentId = string & { readonly __brand: 'AgentId' };
+
+function parseAgentId(input: string): AgentId {
+    if (!isUUID(input)) throw new Error(`Invalid agent id: ${input}`);
+    return input as AgentId;
+}
+
+function focusAgent(id: AgentId): void {
+    /* input is trusted */
+}
+```
+
+Match the `readonly __brand: 'X'` shape; don't invent a new convention.
+
+## Discriminated unions
+
+If a bug forces the question "wait, can this combination actually happen?", the type is too loose. Model variants with a literal discriminant: every variant shares the field name and each variant's value is unique, so impossible combos can't be represented.
+
+```ts
+// Don't. Boolean + optionals lets contradictory states exist.
+type DiffState = { loading: boolean; diff?: GitDiff; error?: string };
+
+// Do. Only valid states exist.
+type DiffState =
+    | { kind: 'loading' }
+    | { kind: 'ready'; diff: GitDiff }
+    | { kind: 'error'; error: string };
+```
+
+Pick one discriminant name (`kind`, `type`, `tag`) and stick to it.
+
+## Constructive modeling
+
+Build the type from parts that are all legal instead of restricting a loose type with runtime checks. Adding is easier than subtracting.
+
+Non-empty, via a variadic tuple:
+
+```ts
+type NonEmpty<T> = [T, ...T[]];
+
+// Don't: T[] plus a length check every caller must repeat
+function pickWinner(entries: string[]): string {
+    if (entries.length === 0) throw new Error('no entries');
+    return entries[Math.floor(Math.random() * entries.length)];
+}
+
+// Do: an empty value of the type can't exist
+function pickWinner(entries: NonEmpty<string>): string {
+    return entries[Math.floor(Math.random() * entries.length)];
+}
+```
+
+Where a plain `T[]` arrives, narrow once with a guard. The fact then travels in the type:
+
+```ts
+const isNonEmpty = <T>(arr: T[]): arr is NonEmpty<T> => arr.length > 0;
+```
+
+Even length, as pairs. TypeScript has no refinement types (no `arr.length % 2 === 0` at the type level); you don't need one:
+
+```ts
+type Pairs<T> = [T, T][];
+```
+
+A time range, as start plus duration:
+
+```ts
+// Don't: a comment holds the invariant
+type TimeRange = { start: Date; end: Date }; // start <= end
+
+// Do: a negative range can't be written; derive end when needed
+type TimeRange = { start: Date; durationMs: number };
+```
+
+Keep `durationMs` a plain number. Brand it (per Branded types) only if a raw number could be passed where a duration is expected, not by reflex. A `Pairs<T>` is an even-length list under the interpretation you give it, the same way `{ start, durationMs }` is a range. Pick the representation that makes the bad state unconstructable, then expose the reading you need on top (`pairs.flat()`, a `rangeEnd()` helper).
+
+## Simplest total type
+
+Don't strengthen everything. Keep `T[]` when every operation on it is total:
+
+```ts
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0); // [] is 0, fine
+```
+
+Strengthen when the loose type forces a lie at a use site. The tells are `!`, `arr[0] as T`, and a "should never happen" throw:
+
+```ts
+// Don't: partiality smuggled past the compiler
+function newestSession(sessions: Session[]): Session {
+    return sessions.at(0)!;
+}
+
+// Do: strengthen the input; the assertion disappears
+function newestSession(sessions: NonEmpty<Session>): Session {
+    return sessions[0];
+}
+```
+
+Weakening the result to `Session | undefined` is the other total signature. Either way the empty case lands at the call site, the one place that knows what empty means.
+
+## `unknown` over `any`
+
+`any` disables type checking for everything it touches. External data is always `unknown`. Narrow before use.
+
+```ts
+// Don't
+function handle(input: any) {
+    return input.foo.bar;
+}
+
+// Do
+function handle(input: unknown) {
+    if (typeof input === 'object' && input !== null && 'foo' in input) {
+        // narrowed; compiler verifies access
+    }
+}
+```
+
+External sources include RPC payloads, `JSON.parse`, `postMessage`, IPC, file contents, environment variables, database results.
+
+## No `as` casts
+
+Every `as` is a potential runtime crash. Cast only after the type system has verified the claim.
+
+```ts
+// Don't
+const user = data as User;
+
+// Do. Earn the cast at the boundary.
+function parseUser(data: unknown): User {
+    if (typeof data !== 'object' || data === null) {
+        throw new Error('expected object');
+    }
+    if (!('id' in data) || typeof (data as Record<string, unknown>).id !== 'string') {
+        throw new Error('expected id');
+    }
+    // ... validate all fields
+    return data as User; // OK, earned cast after full validation
+}
+```
+
+When refactoring an `as` out of existing code, identify why TypeScript can't infer:
+
+- Missing discriminant: add one, switch to a discriminated union.
+- Overly wide source type (e.g. `Record<string, unknown>`): narrow it.
+- Untyped boundary: add a parse function or schema.
+- Genuinely inexpressible: use a branded type or `satisfies`.
+
+## Narrowing hierarchy
+
+From best to last-resort:
+
+1. **Discriminated union switch / if.** Compiler narrows automatically.
+2. **`in` operator.** `"key" in obj` narrows to variants containing that key.
+3. **`typeof` / `instanceof`.** For primitives and class instances.
+4. **User-defined type guard.** When the above aren't enough.
+5. **`as` cast.** Only after validation.
+
+```ts
+function area(s: Shape): number {
+    if ('radius' in s) return Math.PI * s.radius ** 2; // narrowed to circle
+    return s.width * s.height; // narrowed to rect
+}
+```
+
+## Type guards
+
+A guard must actually verify the claim. A lying guard is worse than `as` because the bug hides behind a name that says it's safe.
+
+```ts
+function isCircle(s: Shape): s is Shape & { kind: 'circle' } {
+    return s.kind === 'circle';
+}
+```
+
+Prefer discriminant narrowing when possible. The guard adds a layer the reader has to follow.
+
+## Exhaustiveness
+
+In default arms, assign the discriminant to a `never`-typed local. The compiler errors if a new variant is added without handling.
+
+```ts
+// Value-returning switch
+function area(s: Shape): number {
+    switch (s.kind) {
+        case 'circle':
+            return Math.PI * s.radius ** 2;
+        case 'rect':
+            return s.width * s.height;
+        default: {
+            const _exhaustive: never = s;
+            return _exhaustive;
+        }
+    }
+}
+
+// Void switch
+function handle(s: Shape): void {
+    switch (s.kind) {
+        case 'circle':
+            drawCircle(s);
+            break;
+        case 'rect':
+            drawRect(s);
+            break;
+        default: {
+            const _exhaustive: never = s;
+            void _exhaustive;
+        }
+    }
+}
+```
+
+Return-style in value-returning switches; void-style in statement switches.
+
+## `satisfies` over `as`
+
+`satisfies` validates without widening literal types.
+
+```ts
+// Don't. Widens, loses literal types.
+const config = { theme: "dark", cols: 3 } as Config;
+
+// Do. Validates AND preserves literal types.
+const config = { theme: "dark", cols: 3 } satisfies Config;
+// config.theme is "dark" (literal), not string
+```
+
+## Boundary validation
+
+Validate once where data crosses in; trust types inside. See the **boundary-discipline** principle skill.
+
+- **Wire formats** (proto, JSON-RPC): parse with `ignoreUnknownFields` so forward-compatible changes don't break old clients.
+- **Persisted JSON:** versioned blob with a try/catch around the parse.
+- **Don't re-validate** deep in call chains.
+
+## Schema-derived types
+
+When a `.proto`, OpenAPI spec, GraphQL schema, or database migration already defines a shape, derive from the generated types instead of duplicating them.
+
+```ts
+// Do. Derive from the generated schema type.
+import type { ChecksMessage } from '<generated module>';
+
+// Don't. Duplicate shape, drifts when the schema changes.
+type CheckSummary = {
+    totalCount: number;
+    checks: { name: string; status: string }[];
+};
+function renderChecks(s: CheckSummary) {
+    /* ... */
+}
+
+function renderChecks(s: Pick<ChecksMessage, 'totalCount' | 'checks'>) {
+    /* ... */
+}
+```
+
+Reach for `Pick`, `Omit`, `Parameters`, `ReturnType`, `Awaited`, `typeof` before writing a new interface.
+
+## Object args
+
+```ts
+// Don't. Swap two args, still compiles.
+openFile(uri, {
+    startLineNumber: 10,
+    startColumn: 1,
+    endLineNumber: 10,
+    endColumn: 1,
+});
+
+// Do. Order-independent, self-documenting.
+openFile({
+    uri,
+    selection: {
+        startLineNumber: 10,
+        startColumn: 1,
+        endLineNumber: 10,
+        endColumn: 1,
+    },
+});
+```
+
+Skip on hot paths: per-frame render, tokenizers, parsers, anything in a tight loop where the allocation cost matters.

--- a/.agents/skills/unslop/SKILL.md
+++ b/.agents/skills/unslop/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: unslop
+description: Cut AI tells from any writing. Must always apply.
+---
+
+# Unslop
+
+Edit text to remove AI patterns and add human voice.
+
+## Process
+
+1. Scan for the patterns below.
+2. Rewrite. Preserve meaning, match intended tone.
+3. Add soul (see next section).
+4. Self-audit: "What makes this obviously AI generated?" Fix remaining tells.
+
+## Adding soul
+
+Removing patterns is half the job. Sterile, voiceless writing is just as obvious.
+
+- **Have opinions.** React to facts instead of neutrally listing pros and cons.
+- **Vary rhythm.** Short sentences. Then longer ones that take their time. Mix it up.
+- **Acknowledge complexity.** "Impressive but also kind of unsettling" beats "impressive."
+- **Use "I" when it fits.** First person isn't unprofessional.
+- **Let some mess in.** Perfect structure looks machine-made.
+- **Be specific.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am."
+
+## Patterns to detect and fix
+
+### Content
+
+1. **Puffery.** "pivotal moment", "testament to", "evolving landscape", "setting the stage for", "indelible mark", "deeply rooted". Cut puffery, state what happened.
+2. **Name-dropping.** Listing media outlets without context. Pick one, say what was said.
+3. **Superficial -ing phrases.** "highlighting...", "ensuring...", "reflecting...", "showcasing...", "fostering...". Delete or expand with real sources.
+4. **Promotional language.** "nestled", "vibrant", "breathtaking", "groundbreaking", "renowned", "stunning", "must-visit". Use neutral descriptions.
+5. **Vague attributions.** "Experts believe", "Industry reports suggest", "Some critics argue". Name the source or delete.
+6. **Formulaic challenges.** "Despite challenges... continues to thrive." Replace with specific facts.
+
+### Language
+
+7. **AI vocabulary.** Additionally, crucial, delve, enduring, enhance, fostering, garner, interplay, intricate, landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore, vibrant. Replace with plain words.
+8. **Fancy ways to say "is".** "serves as", "stands as", "boasts", "features". Just say "is" or "has".
+9. **"Not just X, but Y."** State the point directly instead.
+10. **Rule of three.** Forcing ideas into groups of three. Use the natural number.
+11. **Synonym cycling.** Protagonist, main character, central figure, hero all in one paragraph. Pick one, repeat it.
+12. **False ranges.** "from X to Y" where X and Y aren't on a meaningful scale. List topics directly.
+
+### Style
+
+13. **Em dash overuse.** Avoid em dashes entirely. Use periods or commas only (no parentheses, no en dashes, no hyphen-as-dash substitutes). Em dashes are an AI tell, and reaching for parentheses instead just trades one tell for another. If a thought needs separation, end the sentence or use a comma.
+14. **Colon overuse.** Colons are fine before a list or example. Not as mid-sentence connectors. "If you're coming from traditional automation: instead of registering event handlers, you describe conditions" adds nothing with the colon. Rewrite to let the point stand on its own without comparison framing. "Describing when the scheduler should fire works best as plain English." Same meaning, no crutch punctuation.
+15. **Boldface overuse.** Don't bold every proper noun or acronym.
+16. **Inline-header lists.** The tell is a bold label and colon that restates the line: "**Performance:** Performance improved...". Convert those to prose. A bold lead-in that ends in a period, names the item, and is followed by genuinely new detail ("**Schema in TypeScript.** Tables live in one file.") is fine, not a tell.
+17. **Title case headings.** Use sentence case.
+18. **Decorative emojis.** Remove from headings and bullets.
+19. **Curly quotes.** Replace with straight quotes.
+
+### Communication artifacts
+
+20. **Chatbot phrases.** "I hope this helps!", "Let me know if...", "Of course!", "Certainly!", "Found the smoking gun!" Remove.
+21. **Cutoff disclaimers.** "While specific details are limited..." Find sources or remove.
+22. **Sycophantic tone.** "Great question! You're absolutely right!" Respond directly.
+
+### Filler
+
+23. **Filler phrases.** "In order to" becomes "To". "Due to the fact that" becomes "Because". "It is important to note that" gets deleted.
+24. **Excessive hedging.** "could potentially possibly be argued that it might" becomes "may".
+25. **Generic conclusions.** "The future looks bright." State specific plans or facts.
+
+### Jargon
+
+26. **Abstract metaphor nouns.** Substrate, wedge, vector, locus, vantage, nexus, primitive (as noun), harness (as metaphor), surface (as in "API surface"), bedrock, scaffolding (as metaphor), modality, paradigm, gold-plating, ratchet (as metaphor), evacuate (for moving code), endgame, north star, flywheel. These read as technical but usually have a plainer concrete word. "Substrate" becomes "base". "Wedge in" becomes "add". "Vector" becomes "way" or "method". "Gold-plating" becomes "more than the job needs". "Ratchet" becomes the mechanism's real name or "a limit that only tightens". "Evacuate" becomes "move out". "Endgame" becomes "the last phase". Pick the concrete word.
+
+### Plain speech
+
+27. **Say what it does, not how it feels.** "the database stays close at hand", "SQL you can read", "types that follow your schema" name a feeling. The fix names the mechanism or a number: "`.toSQL()` returns the exact string sent to the database", "a column rename fails the build". Ask what the sentence tells the reader to do or know, then write that. If you can't restate it as a concrete instruction, fact, or number, cut it. One more check: if the sentence could appear unchanged in another project's docs, it says nothing about this one. Cut it.
+28. **Shorten or split dense sentences.** If the reader has to backtrack to parse a sentence, break it in two or drop clauses. One idea per sentence.
+29. **Active voice.** Prefer it. Catch "is/are/was/were + past participle" and name the actor: "queries are validated" becomes "the compiler validates queries", "the file is parsed by the loader" becomes "the loader parses the file". Passive is fine only when the actor is unknown or genuinely doesn't matter.
+30. **Cut adverbs, or use a stronger verb.** "runs quickly" becomes "is fast" or the number. "significantly improves" becomes the measured delta. An adverb propping up a weak verb means the verb is wrong.
+31. **Prefer the plain word.** "utilize" becomes "use", "leverage" becomes "use", "facilitate" becomes "help", "numerous" becomes "many", "in the event that" becomes "if". The fancier synonym is rarely clearer.

--- a/.agents/skills/why/SKILL.md
+++ b/.agents/skills/why/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: why
+description: "Use for 'why does X work this way', 'why we picked Y', design rationale, regressions, postmortems, or data-backed thresholds. Discovers available MCPs and queries each evidence category (source control, issue tracker, long-form docs, real-time chat, infrastructure observability, error tracking, product analytics warehouse) in parallel, then returns a cited read on decisions and tradeoffs. Use how for runtime behavior."
+---
+
+# Why
+
+Investigate the motivation and intent behind code. Why was it built this way? What edge cases were considered? What product, business, or operational constraints shaped the design? What alternatives were rejected, and why?
+
+Companion to the `how` skill. `how` answers what the code does and how it works. `why` answers what forces led to its shape.
+
+## How this skill works
+
+Historical context spreads across seven evidence categories: source control history, issue or ticket tracking, long-form documents, real-time team chat, infrastructure observability, error or exception tracking, and product analytics warehouses. You cannot predict from the question alone which one holds the answer, so the skill enumerates available MCPs at run time, maps each to a category, queries all seven in parallel, then synthesizes with explicit confidence calibration. Null results from searched categories are first-class evidence about how the decision was made; report them alongside positive findings. The default is coverage, not minimalism.
+
+## Operating Posture
+
+Operate as a careful, cautious, precise investigator. Think like a detective piecing together a historical case from fragmentary records. When the record is thin, say so.
+
+Concretely:
+
+- **Evidence before narrative.** Collect the pieces first, then see what story they support. Never pick a story and recruit the evidence that fits it.
+- **Precision over polish.** Prefer the exact quote and citation over a smooth paraphrase. A reader should be able to follow any claim back to its source and verify it in under a minute.
+- **Consider what you haven't seen.** The evidence you find is a sample, not the whole truth. Before concluding, ask what you would expect to see if an alternative explanation were true, and whether you looked for it.
+- **Name the gaps.** If a thread goes cold, a source isn't searchable, or a question has no answer, document the gap. Don't paper it over with an authoritative-sounding guess.
+- **Hedge on purpose.** When evidence is indirect, your language should signal it ("appears to", "likely", "suggests"). Confidence-matching phrasing is a feature of the output, not a stylistic choice the synthesizer may override.
+- **No shortcut by code-reading.** The code tells you what it does, rarely why it exists. Resist inferring intent from code shape.
+
+This posture is the working method, not a disclaimer.
+
+## Core Epistemics
+
+This skill builds a **patchwork understanding** from fragmented historical evidence. Tickets go stale. Chat threads get deleted. Commit messages lie. People change their minds between the PR description and the implementation. The original author may have left the company.
+
+Be ruthlessly honest about what you know versus what you're inferring. The goal is not a satisfying story; it is to surface evidence, calibrate confidence, and let the user decide.
+
+Principles:
+
+- **Cite everything.** Every claim about intent should reference a specific commit hash, PR number, ticket ID, doc URL, chat permalink, or code comment. If you can't cite it, it's inference, not fact, and must be labeled as such.
+- **Prefer "appears to" over "because".** Hedge when evidence is indirect. Reserve confident language for direct, explicit evidence.
+- **Surface contradictions.** If two sources disagree, show both. Don't quietly pick the one that fits your narrative.
+- **Acknowledge gaps.** If a question has no answer in any source you searched, say so. An honest "we couldn't find out why" beats a confident guess.
+- **Multiple hypotheses are valid.** When the evidence fits several stories, present them all with the evidence for each. Let the user triangulate.
+- **Beware rationalization.** Code that makes sense today may have been written for reasons that no longer apply, or for no good reason at all. Don't retrofit intent.
+
+Read `references/epistemics.md` for the full confidence framework and phrasing guide. The synthesizer must follow it.
+
+## Step 1. Understand the Target and the Question
+
+Parse what the user is asking. The **target** is usually a chunk of code, a pattern, a feature, or a named design decision. The **question** is usually one of:
+
+- "Why was X designed this way?" Design rationale.
+- "Why do we do X instead of Y?" Tradeoff or alternatives.
+- "What edge cases motivated this?" Defensive reasoning.
+- "What business or product constraint led to this?" External forcing function.
+- "Why does this code still exist?" Dead-code territory.
+- "What's the history of X?" Broad archaeological sweep.
+
+If the target is vague ("why do we do it this way?" with no clear referent), make your best guess from conversation context (open files, recent edits, cursor location, what was just discussed). State your interpretation briefly so the user can redirect if you're off, then proceed.
+
+## Step 2. Establish the Code Anchor
+
+Before spawning investigators, anchor the investigation in concrete code. You need:
+
+- The relevant file path(s) and line range(s)
+- The key symbols (function names, class names, constants)
+- An initial commit list. The last few commits touching the target.
+- PR numbers from merge commits (pattern `(#1234)` in the subject line)
+
+Build this inline. It's cheap, and every investigator needs it.
+
+```bash
+# Blame target lines for last-touch commits
+git blame -L <start>,<end> <file>
+
+# Full file history, with patches, through renames
+git log --follow -p -- <file>
+
+# Last N commits touching the file, PR numbers visible
+git log --oneline -20 -- <file>
+
+# Extract PR numbers from a commit message
+git log -1 --format=%B <commit>
+```
+
+Pull PR bodies and discussion via `gh` for any substantive commits:
+
+```bash
+gh pr view <number> --json title,body,author,createdAt,mergedAt,labels,closingIssuesReferences,comments,reviews
+```
+
+Capture this as seed context (file paths, symbols, commits, PR numbers, linked ticket IDs). Pass it to the investigators so they don't rediscover it.
+
+## Step 3. Spawn Parallel Investigators (default posture)
+
+**Default to the full parallel investigation.** Each evidence category lives in a different kind of system, and you cannot tell from the question alone which one holds the answer without looking. So look across every available category, in parallel, by default.
+
+### Discovery
+
+Before spawning investigators, list the available MCPs from the Cursor environment. Use the available-tools map when present. Otherwise inspect the `mcps/` directory Cursor exposes for enabled MCP servers.
+
+Map each available MCP to one evidence category:
+
+1. Source control history
+2. Issue / ticket tracker
+3. Long-form documents
+4. Real-time team chat
+5. Infrastructure observability
+6. Error / exception tracking
+7. Product analytics warehouse
+
+Source control is always available through git and `gh`. For the other six, classify using the MCP name, server instructions, tool names, and resource descriptors. If an MCP could fit more than one category, choose the one matching its primary evidence. Record ambiguous cases in the coverage map.
+
+Aim for a complete **coverage map**, not a minimal one. A null result from an issue tracker is evidence the decision was not ticketed, a useful fact in itself. Document the null, don't skip the search.
+
+Launch all matching investigators in a single message so they run concurrently. One investigator per category lets each specialize in one tool's query vocabulary and result shape. Don't ask one agent to cover multiple MCPs.
+
+Subagent config (each):
+
+- `subagent_type`: `generalPurpose`
+- `model`: your configured why-investigators model (default `grok-4.6-fast-xhigh`)
+- `readonly`: `false` (agent mode). **Do not use readonly/Ask mode.** It strips MCP access, which disables MCP-backed investigators entirely. The source control investigator would be safe in readonly, but keep modes uniform. Investigators still shouldn't write anything. That's a posture, not a sandbox.
+
+Each investigator gets:
+
+1. The base prompt from `references/investigator-prompt.md`
+2. The category playbook `references/sources/<source>.md` for the selected MCP, adapted from the examples in `references/source-playbook.md`
+3. The cross-cutting `references/sources/incident-postmortem.md` **if the target code looks defensive** (null checks, retry logic, timeout handling, rate limiting, feature flags, egress guards, OOM handlers)
+4. The code anchor from Step 2 (file paths, symbols, commit hashes, PR numbers, ticket IDs)
+5. The user's original question
+
+### Investigator roster. One per available evidence category
+
+Spawn one investigator per category that has a matching MCP. Each owns exactly one tool or MCP.
+
+Each entry lists what the category physically contains and the kind of "why" it uniquely surfaces. Use it to know what to expect back, how to name a gap when a category returns empty, and (only in the rare provably-irrelevant case) to justify a skip. Every category overlaps, but each owns a kind of evidence the others cannot recover.
+
+1. **Source control investigator**. Git history, `gh` for PRs, code comments, tests. Always spawn; the only guaranteed source. Best at surfacing _implementation-time rationale captured during review_. PR descriptions stating the problem, review threads debating alternatives, inline comments encoding non-obvious constraints, test names that encode motivating edge cases, and commit messages linking tickets or incidents. Most trustworthy because it ties directly to the diff that shipped.
+
+2. **Issue / ticket tracker investigator** (e.g. Linear, Jira, GitHub Issues, Plane, Shortcut MCP). Tickets, project docs, status updates, spec attachments. Best at surfacing _the product or business forcing function_. Customer requests ("Acme needs X for their SOC2 audit"), compliance deadlines, parent-initiative framing ("Q3 enterprise readiness"), ticket-level scope changes, and labels that categorize the motivation (`customer:*`, `incident-followup`, `compliance`, `perf-regression`). Strongest when the why is external to engineering.
+
+3. **Long-form documents investigator** (e.g. Notion, Confluence, Google Docs, Coda MCP). PRDs, specs, RFCs, design docs, ADRs, postmortems, team pages, meeting notes. Best at surfacing _long-form design rationale_. Problem statements, explicit "alternatives considered" and "rejected approaches" sections, strategy documents that set priorities, ADRs with finalized decisions, and postmortem action items that tie directly to code. Where the why is written out before it becomes code.
+
+4. **Real-time team chat investigator** (e.g. Slack, Discord, Microsoft Teams, Mattermost MCP). Feature-name and symbol searches, PR URL mentions, incident channels (`#sev-*`, `#incident-*`), author-handle activity around the ship date. Best at surfacing _real-time deliberation that never reached a doc_. Fire-drill decisions during incidents, Q&A between the PR author and reviewers, casual "we decided X because Y" threads, and rationale for small changes that didn't warrant a PRD. Especially important when the source control, ticket, and doc paper trail is thin.
+
+5. **Infrastructure observability investigator** (e.g. Datadog, New Relic, Honeycomb, Grafana, Splunk MCP). Metrics, monitors, dashboards, logs, APM traces, formal incidents. Infra/runtime view. Best at surfacing _infrastructure and runtime reality that motivated the code_. Monitor thresholds whose numbers match code constants, metric spikes in the window right before a PR merge, dashboards created as postmortem action items, incident timelines that reference the target. Strongest when the target reacts to an infra signal (timeouts, retries, rate limits, circuit breakers).
+
+6. **Error / exception tracking investigator** (e.g. Sentry, Rollbar, Bugsnag, Airbrake MCP). Issues, events, stack traces, releases. Best at surfacing _the specific exceptions and error trajectories that motivated defensive or corrective code_. Stack traces that pass through the target function, issues whose first-seen/last-seen windows bracket the PR ship date, release correlations that show an error stopping at a specific version. Strongest for catch blocks, null guards, type checks, retries, and other defenses.
+
+7. **Product analytics warehouse investigator** (e.g. Databricks, Snowflake, BigQuery, ClickHouse, dbt, Redshift MCP). Product-analytics events, experiment and feature-flag exposure tables, usage and billing events, query history, warehouse telemetry. Product/data view. Complements infrastructure observability by covering _user behavior and data reality_ around the ship date rather than infra metrics. Best at surfacing _product and data reality that shaped the code_. Feature-usage trajectories (a step-function ramp from zero is strong evidence that this PR launched it), experiment/flag exposure data tied to ship decisions, pre-ship distributions that reveal where a threshold constant came from (e.g., `limit = 128 * 1024` matching the p99 of an upload-size column), and data-pipeline scale evidence for migrations/backfills. Strongest for flag-gated code, experiment-driven ships, data migrations, and "where did this number come from" questions.
+
+### When to skip an investigator
+
+Only skip with an **explicit, written justification** that goes in the final "Sources Consulted" section. Two valid reasons:
+
+- **No MCP is available for that category** in this environment. Flag this as a gap, not a choice. Example: "Real-time team chat skipped. No matching MCP available, so the conversational record was not searchable."
+- **The source is provably irrelevant**, not just "probably irrelevant." A high bar. Example: "Error / exception tracking skipped. Target is a build-time script with no runtime code path." Not "probably not in error tracking, it's a feature not an error."
+
+"It's pure feature code, error tracking won't have anything" is **not** sufficient, and neither is "I doubt long-form docs would have this." Run the search; let the null result speak. The cost of an investigator returning empty is one subagent. The cost of missing a design doc that actually exists is a wrong answer.
+
+If your scope assessment suggests a single-commit trivial target where the PR description already contains the complete answer, you may answer inline **only after** confirming all seven available category searches would be redundant. Say so explicitly. This should be rare.
+
+## Step 4. Synthesize
+
+Spawn one synthesizer subagent:
+
+- `subagent_type`: `generalPurpose`
+- `model`: your configured why-synthesizer model (default `claude-fable-5-thinking-max`)
+- `readonly`: `false` (agent mode). The synthesizer's quality check spot-verifies citations, which can require MCP access. Readonly/Ask mode strips MCPs and defeats that.
+
+The synthesizer gets:
+
+1. The investigator findings, including any null results and any categories skipped with justification
+2. The code anchor from Step 2 (file paths, symbols, commit hashes, PR numbers, ticket IDs)
+3. The user's original question
+4. The epistemics framework from `references/epistemics.md`
+5. The synthesizer prompt template from `references/synthesizer-prompt.md`
+
+Its job is the final output: a confidence-weighted, evidence-cited narrative with clearly separated "what we know" and "what we're inferring" sections, plus honest acknowledgment of gaps and null-result sources.
+
+## Step 5. Present
+
+Take the synthesizer's output and present it to the user. You may lightly edit for clarity or add context from the conversation, but **do not rewrite the confidence language**. The epistemic framing is the product. Dropping the hedges to sound more authoritative is the exact failure mode this skill exists to prevent.
+
+## Output Format
+
+The final output uses this structure. Adapt as needed, but keep the confidence separation intact.
+
+**The Question**. Restate what the user asked, concisely.
+
+**The Code in Question**. File paths, line ranges, and key symbols. One or two lines so the reader is anchored.
+
+**What We Found (direct evidence)**. Claims with explicit citations (PR #, ticket ID, doc URL, chat permalink, commit hash, code comment with file:line). Each bullet is a thing we have textual evidence for. Use present tense and quote or paraphrase the source.
+
+**What We Can Reasonably Infer**. Claims well-supported by indirect evidence or combinations of signals, but not explicitly stated anywhere. Each bullet must explain the inference chain: "Given A and B, it's likely that C." Use hedged language ("appears to", "likely", "suggests").
+
+**Competing Hypotheses**. If the evidence fits multiple stories, list them. For each, give the hypothesis, the evidence for it, and the evidence against it. Don't force a winner when the record doesn't support one. (Skip this section if there's a clear answer.)
+
+**What We Don't Know**. Explicit gaps. Questions the user asked that the evidence didn't answer. Sources we searched and came up empty. Be specific. "We searched the issue tracker for 'rate limit' and found no ticket discussing this specific threshold" is more useful than "we don't know why."
+
+**Sources Consulted**. One line per investigator, including the ones that returned nothing. The reader should see at a glance (a) which MCPs were queried, (b) which came back empty, and (c) which were skipped and why. This coverage map lets the user judge breadth and redirect if something obvious was missed.
+
+Format each line as: `- <Source>: <what was searched>. <what was found, or "no relevant results," or "skipped. reason">.`
+
+Example:
+
+- Source control (git/gh): `git log --follow backend/retry.ts`, PRs #49074, #47812. Found PR #49074 introduced exponential backoff and linked ENG-4421.
+- Issue tracker (Linear): searched for "retry" and ENG-4421. Found ENG-4421 parent issue but no discussion of backoff parameters.
+- Long-form docs (Notion): searched for "retry policy," "backend retries," "ENG-4421." No relevant results.
+- Real-time team chat (Slack): skipped. No matching MCP available in this environment. Gap: conversational record not searched.
+- Infrastructure observability (Datadog): searched for `retry_count` metric and monitors around 2024-08-14. Found monitor "Upstream 5xx rate > 1%" created same day as PR #49074.
+- Error / exception tracking (Sentry): searched for issues first-seen in Aug 2024 with stack through `retry.ts`. Found issue SENTRY-3821 spiking in the week before the PR.
+- Product analytics warehouse (Databricks): queried `<your_analytics_db>.<schema>.stg_backend_upstream_retry` for the 30-day window around 2024-08-14. Daily failure-classified event count fell from ~1.2k/day pre-PR to <50/day post-PR. Also checked `system.query.history` for relevant migration queries. None found.
+
+After the Sources Consulted block, if the user's `why` question is a precursor to actually changing this code, convert the lineage findings into a Preserve / Change / Avoid / Risk constraint set suitable for planning the change.
+
+## Common Failure Modes to Avoid
+
+- **Confident storytelling**. A plausible narrative built from thin evidence. A bullet with no citation goes in "inferred" or "hypotheses," not "what we found."
+- **Citing the code as evidence for its own intent**. "Handles the null case because it checks for null" is mechanics, not motivation. Motivation comes from an external source (PR discussion, ticket, comment, conversation) or is labeled as inference.
+- **Recency bias**. Assuming the most recent commit is authoritative. The current shape is often the accretion of many earlier decisions. Trace back.
+- **Sycophantic agreement**. If the user suggests a reason ("I assume this is for performance?"), treat it as a hypothesis and check the evidence independently, don't just confirm it.
+- **Skipping the gaps section**. An honest accounting of what you couldn't find out is part of the value.
+- **Skipping investigators by anticipation**. Deciding up front that "long-form docs probably don't have this" or "this isn't an error tracking thing" without searching. The default-to-all-seven posture prevents this. A null result is a data point; a skipped search is a blind spot.
+- **Collapsing investigators into one agent**. Each MCP has its own query vocabulary, result shape, and pitfalls; pooling them dilutes specialization and makes coverage harder to reason about. Always one investigator per category.
+
+## Reference Files
+
+- `references/epistemics.md`. Confidence tiers and phrasing guide. The synthesizer must follow it.
+- `references/investigator-prompt.md`. Base prompt template for investigator subagents.
+- `references/source-playbook.md`. Index pointing at the category playbooks below.
+- `references/sources/*.md`. One self-contained example playbook per category, plus cross-cutting `incident-postmortem.md`. Give an investigator the single file that matches its category and adapt it to the available MCP.
+- `references/synthesizer-prompt.md`. Prompt template for the synthesizer subagent, including the output format.

--- a/.agents/skills/why/references/epistemics.md
+++ b/.agents/skills/why/references/epistemics.md
@@ -1,0 +1,150 @@
+# Epistemics
+
+How to reason about confidence when evidence is historical, fragmentary, and sometimes contradictory, and how to communicate it without flattening it into false certainty.
+
+Code doesn't carry its own motivation. You can read what code does; you can't read _why it exists_. That lives in commits, PRs, tickets, docs, and conversations, all incomplete, biased, and sometimes missing entirely. Pretending otherwise produces confident-sounding guesses that mislead the user.
+
+## Confidence Tiers
+
+Every claim in the final output must sit in one of these tiers. The tier determines which output section the claim goes in and how it's phrased.
+
+### 1. Direct
+
+An explicit, textual citation that answers the question. Not "the code does X so the author must have wanted X." Something an author actually _wrote_ that says why.
+
+Examples:
+
+- A PR description that says "this fixes the bug where users with >1000 items couldn't paginate"
+- A ticket that says "we're adding this because customer Acme requested it in their security review"
+- A code comment that says "// clamp to 100 because the upstream API rejects larger values"
+- A design doc that says "we chose option A over option B because we need persistence across restarts"
+- A chat message from the author saying "switching to this approach since the old one was flaky in tests"
+
+Phrasing: confident, present tense. "This exists because X." Cite the source.
+
+### 2. Supported
+
+Multiple pieces of indirect evidence converge. No single source states it explicitly, but the pattern across sources makes it likely.
+
+Examples:
+
+- The PR title says "improve performance," the ticket is labeled "perf," and the surrounding commits all touch the same hot path
+- Multiple tests were added alongside the change, all exercising edge cases with very large inputs
+- The author's other PRs from the same week all mention the same incident in their descriptions
+
+Phrasing: confident but clearly derived. "The evidence points strongly to X: [the specific pieces]." Cite multiple sources.
+
+### 3. Inferred
+
+A reasonable reading of the context, but nothing explicitly supports it. The reader should understand this is _your interpretation_, not a fact from the record.
+
+Examples:
+
+- The PR doesn't say why, but given the error was happening in production (per the incident channel timing) and the fix was rushed (merged the same day), it was likely a hotfix.
+- The function name suggests retry logic; the retry count is 3; this matches the team's general convention of "3 retries" seen elsewhere in the codebase.
+
+Phrasing: hedged. "It appears", "likely", "suggests", "is consistent with", "one reading is". Make the inference chain explicit: "Given A and B, C seems likely because D."
+
+### 4. Speculative
+
+A plausible hypothesis, but the evidence is thin and other explanations fit equally well. Presenting these is valuable, but mark them clearly as guesses.
+
+Examples:
+
+- "This might be a workaround for a browser bug that's since been fixed, but we found no contemporary evidence of that."
+- "It's possible this threshold was chosen to match an SLA commitment, but no SLA doc references it."
+
+Phrasing: explicitly speculative. "One possibility is X, but we have no direct evidence." Usually lives in the "Competing Hypotheses" section alongside other possibilities.
+
+### 5. Unknown
+
+You looked and couldn't find out. A valid and important outcome. Document it.
+
+Phrasing: "We searched X, Y, and Z and found no evidence of why." Be specific about _what_ you searched. "We couldn't find out" is less useful than "we searched the ticket tracker with keywords A and B, scanned the 6 PRs that touched this file since 2023, and grep'd the repo for string literals matching the threshold; none surfaced a rationale."
+
+## Phrasing Guide
+
+### Words that carry confidence. Use carefully
+
+These imply **Direct** or **Supported** confidence. Don't use them for inferences.
+
+- "because". Implies a causal claim with evidence
+- "the reason is". Same
+- "was designed to". Claims author intent
+- "fixes", "addresses", "solves". Claims the change achieved its goal
+- "the team decided". Claims a group decision happened
+
+If you're using these, you should have a citation immediately adjacent.
+
+### Words that hedge. Use for inferences
+
+- "appears to"
+- "seems to"
+- "likely"
+- "suggests"
+- "is consistent with"
+- "one reading is"
+- "plausibly"
+- "may have been"
+- "the evidence points toward"
+
+These signal that you're interpreting, not reporting. Use them liberally in the "What We Can Reasonably Infer" section.
+
+### Words to avoid
+
+- "obviously". If it were obvious, the user wouldn't be asking
+- "clearly". Almost always precedes a claim that isn't clear
+- "of course". Same
+- "just" (as in "it's just X for performance"). Dismissive and usually hides uncertainty
+- "I think" / "I believe". You're synthesizing evidence, not giving a personal opinion. Use "the evidence suggests" instead.
+
+### Avoid rationalization
+
+Code that "makes sense" today may have been written for reasons that no longer apply, or that were wrong when they were written. Don't retrofit a clean rationale onto messy history.
+
+Resist the urge to:
+
+- Assume the author did the "right" thing and work backward to justify it
+- Assume a consistent pattern across the codebase was intentional when it might be copy-paste
+- Turn an absence of evidence into evidence of absence ("no one mentioned security concerns, so it must not have been a concern")
+
+## The Sycophancy Trap
+
+Users often phrase `why` questions with an embedded hypothesis: "Why do we do it this way, I assume it's for performance?" Don't simply confirm it. Treat it as one candidate among others and check the evidence independently. If the evidence supports it, say so with citations; if not, say so and present what the evidence _does_ support.
+
+The user's guess is a prompt for investigation, not a conclusion to validate.
+
+## When Evidence Contradicts
+
+If two sources disagree (the PR description says one thing, the ticket says another), surface both. Don't pick the one that fits a tidier narrative. A typical pattern:
+
+- **The ticket says** "we need this for customer X's compliance requirement"
+- **The PR says** "cleaning up tech debt in this area"
+
+Both may be true (the ticket motivated the work, the PR is the author's framing of it), or one may be wrong. Present both with their citations and let the user make the call.
+
+## When Evidence Is Missing
+
+An honest "we don't know" is one of the most valuable outputs this skill can produce. The user now knows:
+
+- The answer isn't in the obvious places
+- They'll need to ask a human (the original author, the product owner, the team lead) to find out
+- Or they can decide the question isn't worth pursuing further
+
+Failing to mark a gap and filling it with a confident guess actively harms the user; they'll act on the guess.
+
+When you hit a gap, name it concretely:
+
+- What question you were trying to answer
+- What sources you searched
+- What you searched for in each
+- What you found (nothing, or only tangentially related material)
+
+## Calibration Check Before Finalizing
+
+Before delivering the output, the synthesizer should review every claim in "What We Found" and "What We Can Reasonably Infer" and ask:
+
+1. Does this claim have a citation? If not, either add one or move it to "Inferred" / "Hypotheses".
+2. Is the phrasing calibrated to the tier? (A Direct claim can use "because"; an Inferred claim cannot.)
+3. Am I treating the code itself as evidence for its own intent? If so, that's not evidence. Remove or reclassify.
+4. Does the output include a "What We Don't Know" section? If no gaps are mentioned, that's suspicious. Either the evidence was unusually complete or something is being swept under the rug.

--- a/.agents/skills/why/references/source-playbook.md
+++ b/.agents/skills/why/references/source-playbook.md
@@ -1,0 +1,17 @@
+# Source playbooks
+
+The why skill spawns one investigator per available evidence category, each reading a single source-specific playbook below. The playbooks are concrete examples for common MCPs; adapt them for a different MCP in the same category.
+
+| Category                     | Playbook                                               | Example MCP it documents                                        |
+| ---------------------------- | ------------------------------------------------------ | --------------------------------------------------------------- |
+| Source control history       | [`code-archaeology.md`](./sources/code-archaeology.md) | git, `gh`                                                       |
+| Issue / ticket tracker       | [`linear.md`](./sources/linear.md)                     | Linear (adapt for Jira, GitHub Issues, Plane, Shortcut)         |
+| Long-form documents          | [`notion.md`](./sources/notion.md)                     | Notion (adapt for Confluence, Google Docs, Coda)                |
+| Real-time team chat          | [`slack.md`](./sources/slack.md)                       | Slack (adapt for Discord, Microsoft Teams, Mattermost)          |
+| Infrastructure observability | [`datadog.md`](./sources/datadog.md)                   | Datadog (adapt for New Relic, Honeycomb, Grafana, Splunk)       |
+| Error / exception tracking   | [`sentry.md`](./sources/sentry.md)                     | Sentry (adapt for Rollbar, Bugsnag, Airbrake)                   |
+| Product analytics warehouse  | [`databricks.md`](./sources/databricks.md)             | Databricks SQL (adapt for Snowflake, BigQuery, ClickHouse, dbt) |
+
+Cross-cutting:
+
+- [`incident-postmortem.md`](./sources/incident-postmortem.md). Add this if the target code looks defensive (null checks, retry, timeout, rate limit, feature flag, egress guard, OOM handler).

--- a/.agents/skills/why/references/sources/code-archaeology.md
+++ b/.agents/skills/why/references/sources/code-archaeology.md
@@ -1,0 +1,89 @@
+# Code Archaeology (git + in-repo)
+
+## What this source contains
+
+- Commit history (messages, dates, authors, diffs)
+- PR descriptions, review comments, and discussion threads (via `gh`)
+- Inline code comments, TODOs, FIXMEs, deprecation notes
+- ADRs (architectural decision records) if the repo keeps them
+- Tests. Names and assertions often encode the edge cases that motivated a change
+- Related files modified in the same commits (co-change signal)
+- CHANGELOG entries, release notes in the repo
+- Issue/ticket IDs mentioned in commit messages and PR bodies
+
+The most trustworthy source, tied directly to the code, and the most complete. Everything that went through the repo should be here.
+
+## How to search it
+
+Expand the seed commit list:
+
+```bash
+# Full history of the file through renames
+git log --follow --oneline -- <file>
+
+# Pickaxe: commits that added or removed this exact text
+git log -S '<exact_string_from_code>' -- <file>
+
+# Or for patterns:
+git log -G '<regex>' -- <file>
+
+# Who wrote each line and when
+git blame -L <start>,<end> <file>
+
+# The full diff of a specific commit
+git show <hash>
+
+# Commits between two points affecting this file
+git log <old>..<new> -p -- <file>
+```
+
+For each substantive commit, pull the PR context:
+
+```bash
+# Find the PR number from the merge commit or branch
+git log -1 --format=%B <hash>
+
+# Full PR context: body, review comments, linked issues
+gh pr view <number> --json title,body,author,createdAt,mergedAt,labels,closingIssuesReferences,comments,reviews,files
+
+# The --json reviews and comments fields are where the real signal is
+```
+
+Look for out-of-band docs:
+
+```bash
+# ADRs often live in docs/adr/ or similar
+rg -l -i 'architecture.decision' --glob '*.md'
+
+# TODOs and FIXMEs near the target
+rg -n -C2 '(TODO|FIXME|HACK|XXX|NOTE)' <target_file>
+
+# Related tests. Names often encode the "why"
+rg -l '<symbol>' --glob '*test*'
+```
+
+## What good evidence looks like here
+
+- A PR description that explains the problem being solved, not just the change ("This fixes the pagination bug that caused X")
+- A long review thread where alternatives were debated
+- An inline comment near the target line that explains a non-obvious constraint
+- A test named `test_handles_edge_case_when_X` that reveals an edge case motivating the code
+- A commit message that references a ticket or incident ID
+- A CHANGELOG entry that summarizes the user-visible rationale
+
+## Common pitfalls
+
+- **Squash-merge flatlands.** If the repo squashes PRs, individual commits in the branch history are lost. Fall back to PR body and comments.
+- **Misleading commit messages.** "Small refactor" sometimes hides an intentional behavior change. Look at the diff, not the message.
+- **Cargo-culted patterns.** The author may have copied a pattern without understanding why. Check if the pattern originated earlier in the codebase and investigate _that_ commit.
+- **Bot commits and auto-merges.** Dependabot, Renovate, and automated backports usually don't carry motivation. Skip them when trying to find intent.
+- **Treating code as evidence of intent.** The code itself isn't evidence for why it exists. Evidence comes from commit messages, PRs, comments, tests, docs. Don't cite "the function is named X" as evidence of intent.
+
+## What to return
+
+Every commit/PR/comment that bears on the question, with:
+
+- The exact text (quoted)
+- The hash / PR number / file:line
+- Author and date
+- Whether it's direct (explicitly addresses the question) or circumstantial

--- a/.agents/skills/why/references/sources/incident-postmortem.md
+++ b/.agents/skills/why/references/sources/incident-postmortem.md
@@ -1,0 +1,15 @@
+# Incident & Postmortem Context
+
+Not a separate source, a **cross-cutting angle**. Incidents often motivate defensive code ("we added this check after the X outage"), so if the target looks defensive (null checks, retry logic, timeout handling, rate limiting, feature flags), specifically hunt for incident history across every available source:
+
+- **Notion**: search for postmortems mentioning the target file, feature, or error string
+- **Linear**: look for tickets labeled `incident`, `sev-*`, `postmortem-action-item`, `reliability`
+- **Slack**: search `#sev-*` and `#incident-*` channels around the dates the target code was added
+- **Git**: commits with messages like "fix for incident", "add defensive check", "revert" followed by "re-apply with..." are strong signals
+- **Datadog**: `search_datadog_incidents` for formal incident records with timelines; dashboards and monitors created as postmortem action items
+- **Sentry**: issues whose first-seen/last-seen window aligns with the target's PR ship date; stack traces through the target
+- **Databricks**: product-analytics events that classify an error condition (client-reported failures, user-visible retry events, etc.) often spike during an incident window. A drop in that event count after the target PR ships is circumstantial support that the target code resolved the user-visible symptom, even when Datadog/Sentry signal is noisy.
+
+If you find an incident link, fetch the full postmortem. Postmortems typically have an "Action Items" section that ties directly to code changes. When multiple sources corroborate (a Datadog incident ID appears in a Linear ticket, which appears in a Notion postmortem, which appears in a Slack thread that links to the target PR, and the Databricks error-event count drops after the fix), the evidence is especially strong.
+
+Worth spending time on when the code's defensive character makes an incident-driven origin plausible. Skip it for code that doesn't look defensive.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,15 +22,7 @@ This repository is configured to use Model Context Protocol (MCP) servers for lo
     - "List all storage buckets"
     - "What secrets are in Secret Manager?"
 
-### 3. Filesystem MCP Server
-
-- **Purpose**: Read project files and directory structure
-- **Context**: Local file access for non-code files and logs
-- **Example queries**:
-    - "What files are in the docs directory?"
-    - "Show me the content of the deployment logs"
-
-### 4. Context7 MCP Server
+### 3. Context7 MCP Server
 
 - **Purpose**: Retrieve up-to-date documentation for libraries and frameworks
 - **Context**: External documentation context
@@ -38,14 +30,7 @@ This repository is configured to use Model Context Protocol (MCP) servers for lo
     - "How do I use the new Next.js 15 Image component?"
     - "Find documentation for Zod validation"
 
-### 5. Prisma MCP Server
-
-- **Purpose**: Introspect database schema (alternative to Postgres MCP)
-- **Context**: Prisma schema models and relationships
-- **Example queries**:
-    - "Show me the User model in Prisma"
-
-### 6. GitHub MCP Server
+### 4. GitHub MCP Server
 
 - **Purpose**: Search and read repository content and issues
 - **Context**: Issues, Pull Requests, file content via search
@@ -60,7 +45,6 @@ When answering questions or generating code:
 1. **Reference the MCP servers** when database schema or cloud infrastructure context is needed
 2. **Use actual table and column names** from the Postgres MCP server
 3. **Reference deployed services** from the Google Cloud MCP server
-4. **Check existing files** using the Filesystem MCP server before suggesting new ones
 
 ## Configuration
 
@@ -68,6 +52,5 @@ The MCP servers are configured in `mcp.json` at the repository root:
 
 - `postgres`: Database access via `modelcontextprotocol-server-postgres`
 - `gcloud`: Cloud access via `@google-cloud/gcloud-mcp`
-- `filesystem`: File access via `@modelcontextprotocol/server-filesystem`
-
-For local development setup, see `docs/dev/mcp.md`.
+- `context7`: External doc context via `@upstash/context7-mcp`
+- `github`: Repository access via `@modelcontextprotocol/server-github`

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ pnpm-debug.log*
 # Teamwork Session Files & Workspace Customizations
 .agents/*
 !.agents/skills/
+!.agents/skills.manifest.json
+!.agents/overlays/
 
 # Pawthy CLI Credentials & Local Secrets
 .pawthy/

--- a/ENV.md
+++ b/ENV.md
@@ -80,10 +80,10 @@ The bot name is derived from the variable name:
 > [!IMPORTANT]
 > **PostgreSQL (`DB_TYPE=postgres`)** is strongly encouraged for all live production and staging deployments to ensure ACID durability and support concurrent web dashboard queries. **SQLite** is provided as zero-config local developer experience (DX) and testing infrastructure.
 
-| Variable       | Description                                                             | Default  |
-| -------------- | ----------------------------------------------------------------------- | -------- |
-| `DB_TYPE`      | Database driver: `postgres` (encouraged for live/staging) or `sqlite`   | `sqlite` |
-| `DATABASE_URL` | PostgreSQL connection string (required when `DB_TYPE=postgres`)         | (none)   |
+| Variable       | Description                                                           | Default  |
+| -------------- | --------------------------------------------------------------------- | -------- |
+| `DB_TYPE`      | Database driver: `postgres` (encouraged for live/staging) or `sqlite` | `sqlite` |
+| `DATABASE_URL` | PostgreSQL connection string (required when `DB_TYPE=postgres`)       | (none)   |
 
 **Example PostgreSQL URL:**
 

--- a/apps/bot/src/core/audio/playback-engine.ts
+++ b/apps/bot/src/core/audio/playback-engine.ts
@@ -275,7 +275,12 @@ export async function playSong(queue: Queue): Promise<void> {
             inlineVolume: true,
         });
 
-        const effectiveGain = typeof song.gain === 'number' ? song.gain : (typeof queue.gain === 'number' ? queue.gain : 1.0);
+        const effectiveGain =
+            typeof song.gain === 'number'
+                ? song.gain
+                : typeof queue.gain === 'number'
+                  ? queue.gain
+                  : 1.0;
         resource.volume?.setVolume(effectiveGain);
 
         queue.player.play(resource);

--- a/apps/bot/src/core/music-player.ts
+++ b/apps/bot/src/core/music-player.ts
@@ -301,7 +301,9 @@ async function createQueue(
                     !queue.textChannel.isDMBased()
                 ) {
                     try {
-                        const channel = await queue.worker.client.channels.fetch(queue.voiceChannelId);
+                        const channel = await queue.worker.client.channels.fetch(
+                            queue.voiceChannelId,
+                        );
                         const channelName =
                             channel && 'name' in channel
                                 ? (channel as { name: string }).name
@@ -935,7 +937,9 @@ async function toggleLoop(interaction: ChatInputCommandInteraction): Promise<voi
         queue.loopQueue = false;
     }
 
-    await interaction.reply(`🔂 **Looping is now ${queue.loopTrack ? 'ENABLED (repeating current track)' : 'DISABLED'}**`);
+    await interaction.reply(
+        `🔂 **Looping is now ${queue.loopTrack ? 'ENABLED (repeating current track)' : 'DISABLED'}**`,
+    );
 }
 
 async function toggleRepeat(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -955,7 +959,9 @@ async function toggleRepeat(interaction: ChatInputCommandInteraction): Promise<v
         queue.loopTrack = false;
     }
 
-    await interaction.reply(`🔁 **Queue repeating is now ${queue.loopQueue ? 'ENABLED (repeating the entire queue)' : 'DISABLED'}**`);
+    await interaction.reply(
+        `🔁 **Queue repeating is now ${queue.loopQueue ? 'ENABLED (repeating the entire queue)' : 'DISABLED'}**`,
+    );
 }
 
 async function shuffleQueue(interaction: ChatInputCommandInteraction): Promise<void> {

--- a/mcp.json
+++ b/mcp.json
@@ -2,53 +2,19 @@
     "mcpServers": {
         "postgres": {
             "command": "npx",
-            "args": [
-                "-y",
-                "modelcontextprotocol-server-postgres"
-            ]
+            "args": ["-y", "modelcontextprotocol-server-postgres"]
         },
         "gcloud": {
             "command": "npx",
-            "args": [
-                "-y",
-                "@google-cloud/gcloud-mcp"
-            ]
-        },
-        "filesystem": {
-            "command": "npx",
-            "args": [
-                "-y",
-                "@modelcontextprotocol/server-filesystem",
-                "."
-            ]
+            "args": ["-y", "@google-cloud/gcloud-mcp"]
         },
         "context7": {
             "command": "npx",
-            "args": [
-                "-y",
-                "@upstash/context7-mcp",
-                "--api-key",
-                "${CONTEXT7_API_KEY}"
-            ]
-        },
-        "prisma": {
-            "command": "npx",
-            "args": [
-                "-y",
-                "prisma",
-                "mcp"
-            ],
-            "env": {
-                "DATABASE_URL": "${DATABASE_URL}"
-            },
-            "cwd": "packages/database"
+            "args": ["-y", "@upstash/context7-mcp", "--api-key", "${CONTEXT7_API_KEY}"]
         },
         "github": {
             "command": "npx",
-            "args": [
-                "-y",
-                "@modelcontextprotocol/server-github"
-            ],
+            "args": ["-y", "@modelcontextprotocol/server-github"],
             "env": {
                 "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
             }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
         "prod:preview": "turbo run build && PORT=3000 NODE_ENV=production node apps/bot/dist/index.js",
         "mcp:inspect": "node scripts/test-mcp.js",
         "mcp:sync": "node scripts/sync-mcp.js",
+        "skills:sync": "node scripts/sync-skills.js",
+        "skills:check": "node scripts/sync-skills.js --check",
         "typecheck": "turbo run typecheck",
         "format": "prettier --write \"**/*.{ts,tsx,md}\"",
         "format:plugins": "prettier --write \"apps/bot/src/plugins/**/*.{ts,tsx,md}\"",

--- a/scripts/sync-skills.js
+++ b/scripts/sync-skills.js
@@ -47,20 +47,31 @@ function validateFrontmatter(content, skillName) {
 }
 
 function ensureSymlink(targetPath, linkPath) {
+    const linkDir = path.dirname(linkPath);
+    if (!fs.existsSync(linkDir)) {
+        fs.mkdirSync(linkDir, { recursive: true });
+    }
+
+    const relTarget = path.relative(path.dirname(linkPath), targetPath);
+
     try {
-        const linkDir = path.dirname(linkPath);
-        if (!fs.existsSync(linkDir)) {
-            fs.mkdirSync(linkDir, { recursive: true });
-        }
-        if (fs.existsSync(linkPath) || fs.lstatSync(linkPath).isSymbolicLink()) {
+        const stats = fs.lstatSync(linkPath);
+        if (stats.isSymbolicLink()) {
+            const currentTarget = fs.readlinkSync(linkPath);
+            if (currentTarget === relTarget) {
+                return; // Symlink already correct
+            }
+            // Symlink points to wrong target, replace it
+            fs.unlinkSync(linkPath);
+        } else {
+            console.warn(`   ⚠️ Warning: Non-symlink already exists at ${linkPath}. Skipping.`);
             return;
         }
     } catch {
-        // Link doesn't exist, proceed
+        // Path doesn't exist, proceed to create
     }
 
     try {
-        const relTarget = path.relative(path.dirname(linkPath), targetPath);
         fs.symlinkSync(relTarget, linkPath);
         console.log(`   🔗 Linked: ${path.relative(process.cwd(), linkPath)} -> ${relTarget}`);
     } catch (err) {
@@ -101,12 +112,36 @@ async function syncSkills() {
         console.log(`   Source: ${source.repo} (${config.sourcePath})`);
 
         if (isCheckOnly) {
-            const skillFile = path.join(targetDir, 'SKILL.md');
-            if (fs.existsSync(skillFile)) {
-                console.log(`   ✅ Validated (already present)`);
+            // In repo-level check mode, skip global skills unless explicitly running with --global
+            if (config.scope === 'global' && !process.argv.includes('--global')) {
+                console.log(`   ⏩ Skipped global scope in repo check mode`);
+                continue;
+            }
+
+            let allFilesValid = true;
+            for (const file of config.files) {
+                const destPath = path.join(targetDir, file);
+                if (!fs.existsSync(destPath)) {
+                    console.error(`   ❌ Missing declared file: ${file}`);
+                    allFilesValid = false;
+                    continue;
+                }
+
+                if (file === 'SKILL.md') {
+                    try {
+                        const content = fs.readFileSync(destPath, 'utf8');
+                        validateFrontmatter(content, targetName);
+                    } catch (err) {
+                        console.error(`   ❌ Invalid frontmatter in ${file}: ${err.message}`);
+                        allFilesValid = false;
+                    }
+                }
+            }
+
+            if (allFilesValid) {
+                console.log(`   ✅ Validated (all files present & valid)`);
                 successCount++;
             } else {
-                console.error(`   ❌ Missing on disk`);
                 errorCount++;
             }
             continue;
@@ -125,10 +160,8 @@ async function syncSkills() {
                 let newContent = await fetchUrl(fileUrl);
 
                 if (file === 'SKILL.md') {
-                    // Update name in frontmatter if aliased
-                    if (config.name) {
-                        newContent = newContent.replace(/^name:\s*.+$/m, `name: ${config.name}`);
-                    }
+                    // Ensure name in frontmatter matches registered targetName
+                    newContent = newContent.replace(/^name:\s*.+$/m, `name: ${targetName}`);
 
                     // Apply overlay if specified
                     if (config.overlay) {

--- a/scripts/sync-skills.js
+++ b/scripts/sync-skills.js
@@ -1,0 +1,183 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const https = require('https');
+
+const MANIFEST_PATH = path.join(__dirname, '..', '.agents', 'skills.manifest.json');
+const PROJECT_SKILLS_ROOT = path.join(__dirname, '..', '.agents', 'skills');
+const GLOBAL_SKILLS_ROOT = path.join(os.homedir(), '.gemini', 'config', 'skills');
+
+const isCheckOnly = process.argv.includes('--check');
+
+function fetchUrl(url) {
+    return new Promise((resolve, reject) => {
+        https
+            .get(url, (res) => {
+                if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                    return resolve(fetchUrl(res.headers.location));
+                }
+                if (res.statusCode !== 200) {
+                    return reject(new Error(`HTTP ${res.statusCode} fetching ${url}`));
+                }
+                let data = '';
+                res.on('data', (chunk) => {
+                    data += chunk;
+                });
+                res.on('end', () => resolve(data));
+            })
+            .on('error', reject);
+    });
+}
+
+function validateFrontmatter(content, skillName) {
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!match) {
+        throw new Error(`Skill ${skillName} is missing valid YAML frontmatter (--- ... ---)`);
+    }
+    const yaml = match[1];
+    if (!yaml.includes('name:')) {
+        throw new Error(`Skill ${skillName} frontmatter is missing 'name:' field`);
+    }
+    if (!yaml.includes('description:')) {
+        throw new Error(`Skill ${skillName} frontmatter is missing 'description:' field`);
+    }
+    return true;
+}
+
+function ensureSymlink(targetPath, linkPath) {
+    try {
+        const linkDir = path.dirname(linkPath);
+        if (!fs.existsSync(linkDir)) {
+            fs.mkdirSync(linkDir, { recursive: true });
+        }
+        if (fs.existsSync(linkPath) || fs.lstatSync(linkPath).isSymbolicLink()) {
+            return;
+        }
+    } catch {
+        // Link doesn't exist, proceed
+    }
+
+    try {
+        const relTarget = path.relative(path.dirname(linkPath), targetPath);
+        fs.symlinkSync(relTarget, linkPath);
+        console.log(`   🔗 Linked: ${path.relative(process.cwd(), linkPath)} -> ${relTarget}`);
+    } catch (err) {
+        console.warn(`   ⚠️ Warning: Could not create symlink ${linkPath}: ${err.message}`);
+    }
+}
+
+async function syncSkills() {
+    console.log('🤖 Agent Skills Synchronization Engine');
+    console.log('=======================================');
+
+    if (!fs.existsSync(MANIFEST_PATH)) {
+        console.error(`❌ Manifest not found at: ${MANIFEST_PATH}`);
+        process.exit(1);
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+    const { sources, skills } = manifest;
+
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const [skillKey, config] of Object.entries(skills)) {
+        const source = sources[config.source];
+        if (!source) {
+            console.error(`❌ Unknown source '${config.source}' for skill '${skillKey}'`);
+            errorCount++;
+            continue;
+        }
+
+        const targetName = config.name || skillKey;
+        const targetDir =
+            config.scope === 'global'
+                ? path.join(GLOBAL_SKILLS_ROOT, targetName)
+                : path.join(PROJECT_SKILLS_ROOT, targetName);
+
+        console.log(`\n📦 Processing [${config.scope.toUpperCase()}] skill: ${targetName}`);
+        console.log(`   Source: ${source.repo} (${config.sourcePath})`);
+
+        if (isCheckOnly) {
+            const skillFile = path.join(targetDir, 'SKILL.md');
+            if (fs.existsSync(skillFile)) {
+                console.log(`   ✅ Validated (already present)`);
+                successCount++;
+            } else {
+                console.error(`   ❌ Missing on disk`);
+                errorCount++;
+            }
+            continue;
+        }
+
+        try {
+            fs.mkdirSync(targetDir, { recursive: true });
+
+            for (const file of config.files) {
+                const fileUrl = `${source.baseUrl}/${config.sourcePath}/${file}`;
+                const destPath = path.join(targetDir, file);
+                const destDir = path.dirname(destPath);
+
+                fs.mkdirSync(destDir, { recursive: true });
+
+                console.log(`   ⬇️  Fetching: ${file}`);
+                let content = await fetchUrl(fileUrl);
+
+                if (file === 'SKILL.md') {
+                    // Update name in frontmatter if aliased
+                    if (config.name) {
+                        content = content.replace(/^name:\s*.+$/m, `name: ${config.name}`);
+                    }
+
+                    // Apply overlay if specified
+                    if (config.overlay) {
+                        const overlayPath = path.join(__dirname, '..', config.overlay);
+                        if (fs.existsSync(overlayPath)) {
+                            const overlayContent = fs.readFileSync(overlayPath, 'utf8');
+                            content = `${content.trim()}\n\n---\n${overlayContent.trim()}\n`;
+                            console.log(`   🧩 Applied project overlay: ${config.overlay}`);
+                        }
+                    }
+
+                    // Validate frontmatter
+                    validateFrontmatter(content, targetName);
+                }
+
+                fs.writeFileSync(destPath, content, 'utf8');
+            }
+
+            console.log(`   ✅ Successfully synced ${targetName}`);
+            successCount++;
+        } catch (err) {
+            console.error(`   ❌ Failed to sync ${targetName}: ${err.message}`);
+            errorCount++;
+        }
+    }
+
+    // Ensure Cross-Tool Directory Symlinks for Project Skills
+    if (!isCheckOnly) {
+        console.log('\n🔗 Setting up Cross-Tool Interoperability Symlinks...');
+        ensureSymlink(PROJECT_SKILLS_ROOT, path.join(__dirname, '..', '.cursor', 'skills'));
+        ensureSymlink(PROJECT_SKILLS_ROOT, path.join(__dirname, '..', '.claude', 'skills'));
+
+        // Setup .agent/skills symlink if .agent exists
+        const agentDir = path.join(__dirname, '..', '.agent');
+        if (fs.existsSync(agentDir)) {
+            ensureSymlink(PROJECT_SKILLS_ROOT, path.join(agentDir, 'skills'));
+        }
+    }
+
+    console.log('\n=======================================');
+    console.log(`🏁 Done: ${successCount} synced, ${errorCount} errors`);
+
+    if (errorCount > 0) {
+        process.exit(1);
+    }
+}
+
+syncSkills().catch((err) => {
+    console.error(`Fatal error: ${err.message}`);
+    process.exit(1);
+});

--- a/scripts/sync-skills.js
+++ b/scripts/sync-skills.js
@@ -115,20 +115,19 @@ async function syncSkills() {
         try {
             fs.mkdirSync(targetDir, { recursive: true });
 
+            let skillUpdated = false;
             for (const file of config.files) {
-                const fileUrl = `${source.baseUrl}/${config.sourcePath}/${file}`;
                 const destPath = path.join(targetDir, file);
                 const destDir = path.dirname(destPath);
-
                 fs.mkdirSync(destDir, { recursive: true });
 
-                console.log(`   ⬇️  Fetching: ${file}`);
-                let content = await fetchUrl(fileUrl);
+                const fileUrl = `${source.baseUrl}/${config.sourcePath}/${file}`;
+                let newContent = await fetchUrl(fileUrl);
 
                 if (file === 'SKILL.md') {
                     // Update name in frontmatter if aliased
                     if (config.name) {
-                        content = content.replace(/^name:\s*.+$/m, `name: ${config.name}`);
+                        newContent = newContent.replace(/^name:\s*.+$/m, `name: ${config.name}`);
                     }
 
                     // Apply overlay if specified
@@ -136,19 +135,39 @@ async function syncSkills() {
                         const overlayPath = path.join(__dirname, '..', config.overlay);
                         if (fs.existsSync(overlayPath)) {
                             const overlayContent = fs.readFileSync(overlayPath, 'utf8');
-                            content = `${content.trim()}\n\n---\n${overlayContent.trim()}\n`;
-                            console.log(`   🧩 Applied project overlay: ${config.overlay}`);
+                            newContent = `${newContent.trim()}\n\n---\n${overlayContent.trim()}\n`;
                         }
                     }
 
                     // Validate frontmatter
-                    validateFrontmatter(content, targetName);
+                    validateFrontmatter(newContent, targetName);
                 }
 
-                fs.writeFileSync(destPath, content, 'utf8');
+                // Check if file is already identical on disk
+                let isOutdated = true;
+                if (fs.existsSync(destPath)) {
+                    const existingContent = fs.readFileSync(destPath, 'utf8');
+                    if (existingContent === newContent) {
+                        isOutdated = false;
+                    }
+                }
+
+                if (isOutdated) {
+                    fs.writeFileSync(destPath, newContent, 'utf8');
+                    console.log(
+                        `   ⬇️  ${fs.existsSync(destPath) ? 'Updated' : 'Installed'}: ${file}`,
+                    );
+                    skillUpdated = true;
+                } else {
+                    console.log(`   ⏩ Up to date: ${file}`);
+                }
             }
 
-            console.log(`   ✅ Successfully synced ${targetName}`);
+            if (skillUpdated) {
+                console.log(`   ✅ Synced changes for ${targetName}`);
+            } else {
+                console.log(`   ✨ ${targetName} is already up to date`);
+            }
             successCount++;
         } catch (err) {
             console.error(`   ❌ Failed to sync ${targetName}: ${err.message}`);


### PR DESCRIPTION
## Objective

Establish an automated, standards-compliant, and cross-tool compatible agent skills architecture for Jasper and Hosted Jasper development, supporting Google Antigravity, Cursor, Claude Code, and Codex.

## Summary of Changes

1. **Declarative Skill Manifest (`.agents/skills.manifest.json`)**:
   - Pinned upstream sources (`mattpocock/skills` and `cursor/plugins/pstack`).
   - Declared **12 project skills** (`typescript-best-practices`, `boundary-discipline`, `unslop`, `tdd`, `migrate-then-delete-legacy-apis`, `resolving-merge-conflicts`, `to-spec`, `grill-with-docs`, `why`, `make-operations-idempotent`, `separate-before-serializing-shared-state`, `to-tickets`) and **2 global skills** (`grill-me`, `reflect`).

2. **Sync Engine (`scripts/sync-skills.js`)**:
   - Automated sync runner that downloads, merges local overlays, validates YAML frontmatter, rewrites `name:` keys, repairs symlink drift, and implements incremental diff caching.
   - Added `pnpm run skills:sync` and `pnpm run skills:check`.

3. **Cross-Tool Interoperability**:
   - Added canonical `.agents/skills/` directory.
   - Configured cross-tool compatibility symlinks for `.cursor/skills`, `.claude/skills`, and `.agent/skills`.

4. **Hosted Jasper Overlays**:
   - Added `.agents/overlays/to-spec.md`, `.agents/overlays/grill-with-docs.md`, and `.agents/overlays/to-tickets.md` providing architectural context grounded in `docs/hosted-jasper/` and `.agent/rules/`.

5. **Documentation & MCP Alignment**:
   - Updated `.github/copilot-instructions.md` and `mcp.json` to reflect active MCP servers (`postgres`, `gcloud`, `context7`, `github`).

## Verification

- `pnpm run skills:check`: Passed with 12 project skills verified on disk with 0 errors.
- `pnpm --filter jasper-bot test`: Passed (84/84 tests across 14 suites).
- `pnpm run typecheck`: Passed with 0 errors across workspace packages.