### PR TITLE
[HJ-OSS-15] Correct onboarding and operational documentation drift

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -107,10 +107,8 @@ Logs out the user.
 
 ## Roadmap & Future Work
 
-- [ ] **Middleware**: Implement a Fastify middleware/hook to protect specific routes (e.g., admin dashboard).
-- [ ] **Role-Based Access Control (RBAC)**:
-    - Fetch user's guilds and roles.
-    - Define permissions (e.g., "DJ", "Admin").
-- [ ] **Token Refresh**: Implement logic to use the `refresh_token` when the `access_token` expires.
-- [ ] **Postgres Implementation**: Fully implement the `upsertUser` and session methods in `PostgresAdapter`.
-- [ ] **State Parameter**: Ensure `@fastify/oauth2` is correctly handling the `state` parameter for CSRF protection (it does by default, but verify).
+- [x] **PostgreSQL Implementation**: `upsertUser` and session methods are implemented in `PostgresAdapter`. Automated integration tests, locked migrations, and strict TLS verification are tracked under [`HJ-OSS-07`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-07--re-scope-122-migrations-postgresql-parity-and-installation-safe-data).
+- [ ] **Default-Deny Route Middleware**: Implement Fastify middleware to enforce default-deny action policies and disable legacy admin surfaces in hosted mode ([`HJ-OSS-09`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-09--make-httpapi-authorization-default-deny-and-close-hosted-legacy-admin)).
+- [ ] **Customer & Staff Auth Separation**: Implement private Discord OAuth (`identify guilds`) with tenant membership and corporate OIDC/MFA for staff ([`HJ-PRV-03`](docs/hosted-jasper/mvp-issue-plan.md#hj-prv-03--build-customer-discord-identity-tenant-and-membership-service) / [`HJ-PRV-04`](docs/hosted-jasper/mvp-issue-plan.md#hj-prv-04--build-staff-oidc-rbac-and-privileged-action-service)).
+- [ ] **Token Refresh**: Automatic refresh of expired Discord OAuth access tokens.
+- [ ] **State Parameter**: Verify `@fastify/oauth2` CSRF state handling in all deployment topologies.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -80,9 +80,9 @@ The deployment is handled automatically by GitHub Actions when you push to the `
 
 ## Troubleshooting
 
-### Node Version & SQLite Engine
+### Node Version & Database Support
 
-Jasper uses Node.js built-in `node:sqlite` for local single-instance storage and PostgreSQL for production environments. Ensure the runtime environment matches Node.js **v24+** (as specified in `.nvmrc`).
+Jasper uses Node.js built-in `node:sqlite` for single-instance storage by default, and supports PostgreSQL for multi-instance or scaled production deployments (configured via `DB_TYPE=postgres` and `DATABASE_URL`). Ensure the runtime environment matches Node.js **v24+** (as specified in `.nvmrc`).
 
 - Recommended Node Version: **v24+**
 - If using `pnpm`, ensure it uses the same Node version as your runtime.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -80,13 +80,12 @@ The deployment is handled automatically by GitHub Actions when you push to the `
 
 ## Troubleshooting
 
-### Node Version Mismatch
+### Node Version & SQLite Engine
 
-If you encounter `ERR_DLOPEN_FAILED` related to `better-sqlite3`, ensure that the Node.js version used to run the bot matches the version used to build dependencies.
+Jasper uses Node.js built-in `node:sqlite` for local single-instance storage and PostgreSQL for production environments. Ensure the runtime environment matches Node.js **v24+** (as specified in `.nvmrc`).
 
 - Recommended Node Version: **v24+**
 - If using `pnpm`, ensure it uses the same Node version as your runtime.
-- To rebuild native dependencies: `pnpm rebuild`
 
 ### Plugin Loading Issues
 
@@ -102,8 +101,10 @@ To start the production server:
 pnpm prod:start
 ```
 
-Ensure `PORT` is set (default is 3000).
+Ensure `PORT` is set (e.g., `PORT=3000`; defaults to `0` / disabled if unset).
 
-- **Restart**: `pm2 restart jasper-bot`
-- **Stop**: `pm2 stop jasper-bot`
+- **Restart**: `pm2 restart Jasper`
+- **Stop**: `pm2 stop Jasper`
 - **Status**: `pm2 status`
+
+> **Note on Deployment Architecture**: This PM2 SSH deployment lane represents the legacy single-host manual path. Production-grade containerization with immutable OCI base images, Docker Compose profiles, and signed release promotion are being established under [`HJ-OSS-14`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-14--publish-jasper-base-image-and-one-container-sqlite-quick-path) and [`HJ-OSS-19`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-19--publish-production-like-self-host-compose-and-recovery-path).

--- a/ENV.md
+++ b/ENV.md
@@ -80,10 +80,10 @@ The bot name is derived from the variable name:
 > [!IMPORTANT]
 > **PostgreSQL (`DB_TYPE=postgres`)** is strongly encouraged for all live production and staging deployments to ensure ACID durability and support concurrent web dashboard queries. **SQLite** is provided as zero-config local developer experience (DX) and testing infrastructure.
 
-| Variable       | Description                                                             | Default  |
-| -------------- | ----------------------------------------------------------------------- | -------- |
-| `DB_TYPE`      | Database driver: `postgres` (encouraged for live/staging) or `sqlite`   | `sqlite` |
-| `DATABASE_URL` | PostgreSQL connection string (required when `DB_TYPE=postgres`)         | (none)   |
+| Variable       | Description                                                           | Default  |
+| -------------- | --------------------------------------------------------------------- | -------- |
+| `DB_TYPE`      | Database driver: `postgres` (encouraged for live/staging) or `sqlite` | `sqlite` |
+| `DATABASE_URL` | PostgreSQL connection string (required when `DB_TYPE=postgres`)       | (none)   |
 
 **Example PostgreSQL URL:**
 

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -56,3 +56,22 @@ apps/bot/src/plugins/
 
 - **Sample Plugin** (`sample-plugin`): A reference implementation demonstrating frontend widgets and pages.
 - **Sound Effect Plugin** (`sound-effect-plugin`): Plays sound effects when bots join channels.
+- **Garage Band** (`garage-band`): Playlist creation and audio enhancement (managed via out-of-tree submodule).
+- **Soundboard** (`soundboard`): Sound effect management and playback.
+
+---
+
+## 🛡️ Security & Execution Boundary
+
+> [!IMPORTANT]
+> **Plugins are Trusted Node Code**: Plugins run in-process with ordinary Node.js authority and share the process memory and runtime environment. Fastify route encapsulation is an organizational primitive, not a security sandbox.
+> In hosted multi-tenant profiles, only build-time allowlisted and integrity-verified plugins are admitted.
+
+### Plugin SDK vNext Roadmap
+
+Under [`HJ-OSS-10`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-10--version-the-plugin-sdk-for-typed-policy-lifecycle-and-capabilities), the Plugin SDK is evolving to include:
+
+1. **Mandatory `GuildScope`**: Explicit `(guildId, installationId)` scoping on all database, asset, and hook interfaces.
+2. **Typed Default-Deny Routes**: JSON Schema validation and action-based access declarations for all plugin HTTP endpoints.
+3. **Lifecycle Disposal Handles**: Clean unbind handles for all registered hooks and scheduled tasks upon plugin unload.
+4. **Isolated Audio Enqueue**: Stable audio enqueue service ([`HJ-OSS-13`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-13--expose-stable-plugin-audio-enqueue-service)) replacing direct imports into core music player code.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -65,7 +65,7 @@ apps/bot/src/plugins/
 
 > [!IMPORTANT]
 > **Plugins are Trusted Node Code**: Plugins run in-process with ordinary Node.js authority and share the process memory and runtime environment. Fastify route encapsulation is an organizational primitive, not a security sandbox.
-> In hosted multi-tenant profiles, only build-time allowlisted and integrity-verified plugins are admitted.
+> In target hosted multi-tenant profiles ([`HJ-OSS-10`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-10--version-the-plugin-sdk-for-typed-policy-lifecycle-and-capabilities) / [`HJ-OSS-20`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-20--enforce-installation-and-provider-operational-safety-policy)), only build-time allowlisted and integrity-verified plugins will be admitted.
 
 ### Plugin SDK vNext Roadmap
 

--- a/PLUGINS_DEV.md
+++ b/PLUGINS_DEV.md
@@ -518,3 +518,11 @@ In production (`NODE_ENV=production`), test plugins are automatically disabled:
 The `soundboard` and `sound-effect-plugin` plugins remain enabled as they are functional features.
 
 You can override these defaults using the CLI commands above.
+
+---
+
+## 🛡️ Security & Trust Guidelines
+
+- **In-Process Execution**: Plugins run in the primary Node.js process and share memory and environment variables. Do not install untrusted third-party plugin ZIP archives.
+- **Tenant Scope (vNext)**: When building plugins for multi-guild or hosted deployments, avoid storing global state in `context.db.plugin`. Always namespace persistent data by guild or installation context ([`HJ-OSS-10`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-10--version-the-plugin-sdk-for-typed-policy-lifecycle-and-capabilities)).
+- **Safe Remote Fetching**: Never fetch remote URLs directly with `axios` or raw `fetch` without validating destination hostnames against private IP ranges (SSRF prevention). Use the centralized safe-fetch utility when available ([`HJ-OSS-08`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-08--add-installation-scoped-storage-providers-and-safe-media-ingestion)).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It uses **yt-dlp** (an external command-line tool) to stream high-quality audio,
 - **Slash Commands:** Modern, easy-to-use interface.
 - **Reliable Search:** Uses `yt-search` for accurate video results.
 - **Direct URL Support:** Plays YouTube links directly, skipping search.
-- **Queue System:** View, skip, stop, and manage music queues per server.
+- **Queue System:** View, skip, stop, and manage music queues per voice channel.
 - **Autoplay:** Automatically finds and plays related songs when the queue ends.
 - **Voice Status Updates:** Updates the voice channel status to show the currently playing song.
 - **Now Playing:** Shows rich embeds with video thumbnails, duration, and interactive controls.
@@ -90,14 +90,14 @@ This ensures the project remains open, resilient, supported, and future-proof wh
 
 Jasper supports a unique **Controller + Worker** architecture.
 
-- **Jasper (Controller):** The main bot you interact with via Slash Commands (`/play`, `/stop`).
-- **Workers (Misty, Tuki, etc.):** Additional bot accounts that handle the actual audio playback.
+- **Jasper (Controller):** The primary bot coordinating slash commands (`/play`, `/stop`), and an active AFR participant that also provides fallback playback when workers are unavailable.
+- **Workers (Misty, Tuki, etc.):** Additional bot accounts that handle concurrent audio playback across voice channels.
 
 **How it works:**
 
 1. You send a command to Jasper: `/play song`.
-2. With **Automatic Feline Rotation (AFR)**, Jasper has a 50% chance of joining your channel himself.
-3. The other 50% of the time, he'll summon a random **Worker Bot** (e.g., Misty or Tuki) to handle the music.
+2. With **Automatic Feline Rotation (AFR)**, Jasper probabilistically selects who joins your channel (default 50% Jasper, 50% distributed among available worker cats).
+3. If all workers are occupied or unavailable, Jasper himself steps in as the fallback player.
 4. Each cat announces their arrival with unique, randomized messages! 🐾
 5. This allows multiple voice channels to have music simultaneously, all controlled via Jasper!
 
@@ -268,10 +268,10 @@ Cache statistics are logged on bot startup and during cleanup:
 
 ### Supported Database Engines
 
-Jasper supports dual database drivers out of the box via an abstraction layer with 100% feature parity:
+Jasper supports dual database drivers out of the box via a unified persistence abstraction:
 
-1. **PostgreSQL (Strongly Recommended for Production & Staging)**: High performance, durable ACID persistence, and support for concurrent web dashboard queries. **Required for production and live staging environments with real users.**
-2. **SQLite (Local DX & Testing)**: Zero-configuration file-based database stored in `data/jasper.db`. Ideal for local developer workflows, automated test suites, and single-instance environments.
+1. **SQLite (Default / Local DX & Single-Instance)**: Zero-configuration file-based database powered by Node.js built-in `node:sqlite` (stored in `data/jasper.db`). Ideal for local developer workflows, automated test suites, and single-instance self-hosters.
+2. **PostgreSQL (Production & Multi-Tenant Staging)**: High performance, durable ACID persistence with connection pooling. Comprehensive migration locking, column parity, and strict TLS enforcement are tracked under [`HJ-OSS-07`](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-07--re-scope-122-migrations-postgresql-parity-and-installation-safe-data).
 
 ### Configuration
 
@@ -283,7 +283,7 @@ DB_TYPE=postgres
 DATABASE_URL=postgresql://user:password@localhost:5432/jasper_db
 ```
 
-If `DB_TYPE` is omitted, Jasper defaults to `sqlite` for seamless local developer onboarding.
+If `DB_TYPE` is omitted, Jasper defaults to `sqlite` for zero-configuration onboarding.
 
 ### Viewing Statistics
 
@@ -318,7 +318,7 @@ Once enabled, start the bot and visit:
 
 ## Tech Stack
 
-- **Runtime:** Node.js (v18+)
+- **Runtime:** Node.js (v24+)
 - **Language:** TypeScript (strict mode)
 - **Architecture:** Monorepo (Turborepo + pnpm/pnpm workspaces)
 - **Bot Framework:** [discord.js](https://discord.js.org/) v14
@@ -331,7 +331,7 @@ Once enabled, start the bot and visit:
 
 Before installing, ensure you have:
 
-1.  **Node.js** (v18 or higher) installed.
+1.  **Node.js** (v24 or higher, as specified in `.nvmrc` and `package.json`).
     - **Note:** Node.js is also used by yt-dlp for JavaScript execution during YouTube extraction.
 2.  **FFmpeg** (The bot attempts to use a static binary, but having it installed globally is recommended).
 3.  **yt-dlp.exe** (Required for streaming).

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "quick-start": "bash scripts/quick-start.sh",
         "env:pull": "pawthy pull -f .env --merge",
         "env:push": "pawthy push -f .env",
+        "start": "pnpm --filter jasper-bot start",
+        "deploy:commands": "pnpm --filter jasper-bot run deploy:commands",
         "prod:build": "turbo run build",
         "prod:start": "PORT=3000 NODE_ENV=production node apps/bot/dist/index.js",
         "prod:preview": "turbo run build && PORT=3000 NODE_ENV=production node apps/bot/dist/index.js",


### PR DESCRIPTION
## Objective
Resolves #142 ([HJ-OSS-15](docs/hosted-jasper/mvp-issue-plan.md#hj-oss-15--correct-onboarding-document-drift)). Correct verified documentation drift across `README.md`, `AUTH.md`, `DEPLOY.md`, `ENV.md`, `PLUGINS.md`, and `PLUGINS_DEV.md` to align onboarding instructions with the executable codebase and the locked master architectural decision record.

## Summary of Changes

1. **Runtime Prerequisites & Setup Alignment (`README.md`)**:
   - Updated minimum engine version from `Node.js v18+` to **`Node.js v24+`** (matching `.nvmrc` and `package.json`).
   - Corrected AFR architecture description: documented controller participation in AFR and fallback playback role.
   - Clarified that music queues are scoped per voice channel rather than globally per server.
   - Updated database documentation: noted built-in `node:sqlite` default and PostgreSQL migration locking under `HJ-OSS-07`.

2. **Authentication Status Alignment (`AUTH.md`)**:
   - Marked PostgreSQL adapter implementation as completed in code, tracking automated integration tests, locked migrations, and strict TLS enforcement under `HJ-OSS-07`.
   - Added roadmap pointers for default-deny route authorization (`HJ-OSS-09`) and customer/staff identity separation (`HJ-PRV-03` / `HJ-PRV-04`).

3. **Deployment Guides & Troubleshooting (`DEPLOY.md`)**:
   - Corrected PM2 process name to `Jasper` (matching `ecosystem.config.cjs`).
   - Corrected runtime default web port description (`PORT=0` / disabled by default).
   - Replaced legacy `better-sqlite3` troubleshooting with `node:sqlite` engine guidance.
   - Added architectural note referencing containerized OCI / Compose deployment paths (`HJ-OSS-14` / `HJ-OSS-19`).

4. **Plugin Security & SDK vNext Context (`PLUGINS.md`, `PLUGINS_DEV.md`)**:
   - Added security trust advisory clarifying that in-process Node plugins are trusted code sharing process memory.
   - Documented Plugin SDK vNext roadmap highlights (`GuildScope` mandate, default-deny route schemas, and disposal handles under `HJ-OSS-10`).

5. **Root Convenience Scripts (`package.json`)**:
   - Added root proxy scripts for `start` (`pnpm --filter jasper-bot start`) and `deploy:commands` (`pnpm --filter jasper-bot run deploy:commands`).

## Verification

- `pnpm run format`: Formatted all markdown and JSON files cleanly.
- `pnpm run lint`: 0 errors.
- `pnpm run typecheck`: Passed (3/3 workspace packages).
- `pnpm --filter jasper-bot test -- --run`: Passed (84/84 tests across 14 suites).
- `pnpm run build`: Built all packages and apps cleanly.
